### PR TITLE
UserReaction being tracked in the Message Object 

### DIFF
--- a/Client/src/hooks/useTrackAnalytics.ts
+++ b/Client/src/hooks/useTrackAnalytics.ts
@@ -80,7 +80,7 @@ const useTrackAnalytics = () => {
     userReaction: "like" | "dislike" | null;
   }) => {
     try {
-      await fetch("http://localhost:4000/analytics", {
+      await fetch("http://localhost:4000/analytics/reaction", {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",

--- a/Client/src/redux/message/crudMessage.ts
+++ b/Client/src/redux/message/crudMessage.ts
@@ -73,6 +73,7 @@ export default async function sendMessage(
       sender: "bot",
       text: "Loading...",
       urlPhoto: currentModel.urlPhoto,
+      userReaction: null,
     };
 
     let updateOccurred = false;
@@ -131,3 +132,26 @@ export default async function sendMessage(
     throw error;
   }
 }
+
+export const sendUserReaction = async (
+  logId: string,
+  botMessageId: string,
+  userReaction: "like" | "dislike"
+) => {
+  try {
+    const response = await fetch(`http://localhost:4000/chatLogs/reaction`, {
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      method: "PUT",
+      body: JSON.stringify({ logId, botMessageId, userReaction }),
+    });
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+  } catch (error) {
+    console.error("Failed to send user reaction:", error);
+    throw error;
+  }
+};

--- a/Client/src/types/message/messageType.ts
+++ b/Client/src/types/message/messageType.ts
@@ -12,6 +12,7 @@ export type MessageObjType = {
   text: string; // The text associated with the message
   model?: string; // User only (The assistant title they chose)
   urlPhoto?: string; // Bot only (The url photo corresponding to the message)
+  userReaction: "like" | "dislike" | null;
 };
 
 // Important:

--- a/server/db/models/analytics/messageAnalytics/messageAnalyticsCollection.js
+++ b/server/db/models/analytics/messageAnalytics/messageAnalyticsCollection.js
@@ -34,3 +34,21 @@ export const updateMessageAnalytics = async (userMessageId, updateData) => {
     );
   }
 };
+
+export const updateMessageAnalyticsReaction = async (
+  botMessageId,
+  userReaction
+) => {
+  try {
+    const result = await messageAnalyticsCollection.updateOne(
+      { botMessageId },
+      { $set: { userReaction } }
+    );
+    return result;
+  } catch (error) {
+    console.error("Full error:", error);
+    throw new Error(
+      "Error updating message analytics reaction in database: " + error.message
+    );
+  }
+};

--- a/server/db/models/analytics/messageAnalytics/messageAnalyticsServices.js
+++ b/server/db/models/analytics/messageAnalytics/messageAnalyticsServices.js
@@ -33,3 +33,19 @@ export const updateMessageAnalytics = async (userMessageId, updateData) => {
     );
   }
 };
+export const updateMessageAnalyticsReaction = async (
+  botMessageId,
+  userReaction
+) => {
+  try {
+    const result = await messageAnalyticsModel.updateMessageAnalyticsReaction(
+      botMessageId,
+      userReaction
+    );
+    return result;
+  } catch (error) {
+    throw new Error(
+      "Error updating message analytics reaction in database: " + error.message
+    );
+  }
+};

--- a/server/db/models/chatlog/chatLogCollection.js
+++ b/server/db/models/chatlog/chatLogCollection.js
@@ -46,6 +46,19 @@ export const updateLogContent = async (
   }
 };
 
+export const updateChatMessageReaction = async (
+  logId,
+  botMessageId,
+  userReaction
+) => {
+  // Use the positional operator to find the message within the content array
+  const result = await chatLogCollection.updateOne(
+    { _id: logId, "content.id": botMessageId }, // Find the document with matching _id and content.id
+    { $set: { "content.$.userReaction": userReaction } } // Use the positional operator $ to target the matching element in content array
+  );
+
+  return result;
+};
 // Delete
 export const deleteLogItem = async (logId) => {
   try {

--- a/server/db/models/chatlog/chatLogServices.js
+++ b/server/db/models/chatlog/chatLogServices.js
@@ -57,3 +57,24 @@ export const deleteLog = async (logId, userId) => {
     throw new Error("Service error: " + error.message);
   }
 };
+
+// Update Chat Message Reaction
+export const updateChatMessageReaction = async (
+  logId,
+  botMessageId,
+  userReaction
+) => {
+  try {
+    const result = await ChatLogModel.updateChatMessageReaction(
+      logId,
+      botMessageId,
+      userReaction
+    );
+    return {
+      message: "Chat message reaction updated successfully",
+      modifiedCount: result.modifiedCount,
+    };
+  } catch (error) {
+    throw new Error("Service error: " + error.message);
+  }
+};

--- a/server/routes/analytics/messageAnalytics.js
+++ b/server/routes/analytics/messageAnalytics.js
@@ -4,6 +4,7 @@ import { authorizeRoles } from "../../middlewares/authMiddleware.js";
 import {
   createMessageAnalytics,
   updateMessageAnalytics,
+  updateMessageAnalyticsReaction,
 } from "../../db/models/analytics/messageAnalytics/messageAnalyticsServices.js";
 const router = express.Router();
 
@@ -40,23 +41,10 @@ router.put("/", async (req, res) => {
   console.log("Received data:", req.body); // Add this to check incoming data
 
   try {
-    const {
-      userMessageId,
-      userMessage,
-      createdAt,
-      hadError,
-      errorMessage,
-      userReaction,
-    } = req.body;
+    const { userMessageId, userMessage, createdAt, hadError, errorMessage } =
+      req.body;
     if (!userMessageId) {
-      return res.status(400).send("botMessageId is required");
-    }
-
-    // Updated Message Analytics after user reaction
-    if (userReaction) {
-      await updateMessageAnalytics(userMessageId, { userReaction });
-      res.status(200).send("Message updated successfully");
-      return;
+      return res.status(400).send("userMessageId is required");
     }
     // Convert dates to numbers and calculate response time
     const finishedAt = new Date();
@@ -79,4 +67,16 @@ router.put("/", async (req, res) => {
   }
 });
 
+router.put("/reaction", async (req, res) => {
+  try {
+    const { botMessageId, userReaction } = req.body;
+    if (!botMessageId) {
+      return res.status(400).send("botMessageId is required");
+    }
+    await updateMessageAnalyticsReaction(botMessageId, userReaction);
+    res.status(200).send("Message updated successfully");
+  } catch (error) {
+    res.status(500).send("Failed to update message: " + error.message);
+  }
+});
 export default router;

--- a/server/routes/chatLog.js
+++ b/server/routes/chatLog.js
@@ -4,6 +4,7 @@ import {
   getLogsByUser,
   updateLog,
   deleteLog,
+  updateChatMessageReaction,
 } from "../db/models/chatlog/chatLogServices.js";
 import { fetchIds } from "../db/models/threads/threadServices.js";
 import { deleteThread } from "../helpers/openAI/threadFunctions.js";
@@ -88,4 +89,24 @@ router.delete("/:logId", async (req, res) => {
   }
 });
 
+// Update Chat Message Reaction
+router.put("/reaction", async (req, res) => {
+  const { logId, botMessageId, userReaction } = req.body;
+
+  try {
+    if (userReaction && botMessageId) {
+      const result = await updateChatMessageReaction(
+        logId,
+        botMessageId,
+        userReaction
+      );
+      res.status(200).json(result);
+    }
+  } catch (error) {
+    console.error("Failed to update chat message reaction: ", error);
+    res
+      .status(500)
+      .json("Failed to update chat message reaction: " + error.message);
+  }
+});
 export default router;


### PR DESCRIPTION
## Before Changes

- Users were able to submit their rating on a bot's message and it was successfully being saved in our analytics table
- Front-end also managed state for this and had a green thumbs or a red thumbs down. 
- However, we were not saving the userReaction in the ChatLogs collection, so this state for each bot message was not able to save on the frontend.

## Solution

- Add a new property to the message object `userReaction`
- This will also get saved in our MongoDB collection

