### PR TITLE
UI Fixes

### DIFF
--- a/Client/src/components/ui/file-upload.tsx
+++ b/Client/src/components/ui/file-upload.tsx
@@ -6,6 +6,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useAppSelector } from "@/redux";
 
 export const FileUpload = ({
   onChange,
@@ -15,6 +16,7 @@ export const FileUpload = ({
   onChange?: (file: File | null) => void;
   selectedFile?: File | null;
 }) => {
+  const { isSidebarVisible } = useAppSelector((state) => state.layout);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const iconStyles = selectedFile ? "text-emerald-500" : "text-white";
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -42,7 +44,11 @@ export const FileUpload = ({
             </button>
           </TooltipTrigger>
           <TooltipContent>
-            <span className="text-sm text-gray-700 dark:text-gray-300 truncate max-w-xs">
+            <span
+              className={`text-sm text-gray-700 dark:text-gray-300 truncate max-w-xs ${
+                isSidebarVisible ? "ml-10" : ""
+              }`}
+            >
               {selectedFile ? selectedFile.name : "Upload a PDF"}
             </span>
           </TooltipContent>

--- a/Client/src/redux/log/logSlice.ts
+++ b/Client/src/redux/log/logSlice.ts
@@ -150,7 +150,7 @@ const logSlice = createSlice({
         timestamp: timestamp, // Use the timestamp passed in the action
       };
 
-      state.logList.push(newLog);
+      state.logList.unshift(newLog); // Push to the front of the array
     },
     // Reducer to update an existing log in the state (UPDATE)
     updateCurrentChat: (state, action: PayloadAction<LogData>) => {


### PR DESCRIPTION
## ToolTIp FileUpload 

- Margin added to the left, so the text in the tooltip does not get covered up when the sidebar is visible
- Not the best solution as the text still gets covered up when we have a long file name 
- Could improve this later

## New ChatLogs Unshift 

- New Chat Logs get pushed to the front of the logList array using `unshift` instead of `push`
- This allows for the most recent chat log to always be seen at the top