### PR TITLE
Update ChatContainer.tsx

### DIFF
--- a/Client/src/components/chat/ChatContainer.tsx
+++ b/Client/src/components/chat/ChatContainer.tsx
@@ -6,10 +6,29 @@ import { useAppSelector } from "@/redux";
 const ChatContainer = () => {
   const msgList = useAppSelector((state) => state.message.msgList);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
+  const isUserAtBottomRef = useRef(true);
 
   useEffect(() => {
     const messagesContainer = messagesContainerRef.current;
     if (messagesContainer) {
+      const handleScroll = () => {
+        const { scrollTop, scrollHeight, clientHeight } = messagesContainer;
+        // Check if the user is at the bottom (allowing a small offset)
+        const isAtBottom = scrollTop + clientHeight >= scrollHeight - 10;
+        isUserAtBottomRef.current = isAtBottom;
+      };
+      messagesContainer.addEventListener("scroll", handleScroll);
+
+      // Clean up the event listener on unmount
+      return () => {
+        messagesContainer.removeEventListener("scroll", handleScroll);
+      };
+    }
+  }, []); // Empty dependency array ensures this runs once on mount
+
+  useEffect(() => {
+    const messagesContainer = messagesContainerRef.current;
+    if (messagesContainer && isUserAtBottomRef.current) {
       messagesContainer.scrollTop = messagesContainer.scrollHeight;
     }
   }, [msgList]);


### PR DESCRIPTION
## UI Bug

- In the `ChatContainer` component, I would like to stop scrolling to the bottom of the container if the user scrolls up. 
- Application should not fight the user interaction 
- If the user wants to scroll up they should be able to scroll up.

### Keep The Feature

- However, if the user doesn't scroll up then continue the auto-scroll by staying at the bottom of the container

## Solution

- Introduce a new **useRef** called `isUserAtBottomRef` that will keep track of if the user is at the bottom of the chat
- Set up a `scroll` event listener on the `messagesContainerRef` to update `isUserAtBottomRef.current` whenever the user scrolls.
- **handleScroll** function calculates if user is at the bottom by comparing `scrollTop + clientHeight` to `scrollHeight`

### Event Listener Cleanup

- When the component unmounts, we clean up the event listener to prevent memory leaks from occurring. 

## Final Result

- Component will only **Auto-Scroll** when the user is at or near the bottom of the page
- If a user scrolls up, it will respect their current position and not force-scroll to the bottom as new messages are being sent.