### PR TITLE
PDF File Size Error Handling

### DIFF
--- a/Client/src/redux/message/crudMessage.ts
+++ b/Client/src/redux/message/crudMessage.ts
@@ -61,12 +61,15 @@ export default async function sendMessage(
     ]);
 
     if (!response.ok) {
-      if (response.status === 429) {
+      if (response.status === 429 || response.status === 413) {
         // 429 = rate limiting: too many GPT message requests
         const errorData = await response.text();
         throw new Error(errorData);
       }
-      throw new Error(`HTTP error! status: ${response.status}`);
+      // Remove this after testing
+      const errorData = await response.text();
+      console.error("Error: ", errorData);
+      throw new Error(`An unkown error occured. Please try again.`);
     }
 
     let accumulatedText = "";

--- a/Client/src/redux/message/messageSlice.ts
+++ b/Client/src/redux/message/messageSlice.ts
@@ -158,6 +158,9 @@ const messageSlice = createSlice({
     resetMsgList: (state) => {
       state.msgList = [];
     },
+    updateError: (state, action: PayloadAction<string>) => {
+      state.error = action.payload;
+    },
     // Reducer to clear the error state
     clearError: (state) => {
       state.error = null;
@@ -194,6 +197,7 @@ export const {
   addUserMessage,
   updateBotMessage,
   updateUserReaction,
+  updateError,
   clearError,
   setCurrentChatId,
   toggleNewChat,

--- a/server/helpers/azure/blobFunctions.js
+++ b/server/helpers/azure/blobFunctions.js
@@ -40,7 +40,6 @@ export async function handleFileUpload(file) {
     // Step 2: Upload the local file to OpenAI
     const openAIResponse = await uploadFileToOpenAI(localFilePath);
 
-    // (Optional) Step 3: Delete the local file after uploading
     fs.unlinkSync(localFilePath); // Clean up local file after upload
 
     return openAIResponse;


### PR DESCRIPTION
## Server Side

- If a PDF is received that is greater than `1MB`, send an error message back with status code `413` to notify the user that file sizes must be less than `1MB`

## Client Side

- If the file size is greater than `1MB` immediately set the file to `null` and add a user message
- Error message disappears if the file changes and is less than 1MB or if the user submits a message.

## Conclusion

- The server side should never receive a file pdf that is bigger than `1MB` due to how the client does not allow this. However, just in case, it is still implemented to cover all cases. 