### PR TITLE
ChatLog Options Not Visible

### DIFF
--- a/Client/src/components/layout/ChatPage/ChatPageSidebar.tsx
+++ b/Client/src/components/layout/ChatPage/ChatPageSidebar.tsx
@@ -59,8 +59,8 @@ export function ChatPageSidebar() {
           PolyLink
         </Button>
       </SidebarHeader>
-      <ScrollArea className="h-full">
-        <SidebarContent className="border-t border-sidebar-border dark:border-slate-700 flex-1 overflow-x-hidden">
+      <SidebarContent className="border-b border-sidebar-border overflow-x-hidden">
+        <ScrollArea className="h-full">
           <SidebarGroupLabel>Chatlogs</SidebarGroupLabel>
           <SidebarGroup>
             <SidebarMenu>
@@ -77,8 +77,8 @@ export function ChatPageSidebar() {
               )}
             </SidebarMenu>
           </SidebarGroup>
-        </SidebarContent>
-      </ScrollArea>
+        </ScrollArea>
+      </SidebarContent>
       <ChatSidebarFooter />
     </Sidebar>
   );

--- a/Client/src/index.css
+++ b/Client/src/index.css
@@ -55,3 +55,7 @@ body {
   overflow: hidden; /* Prevent scrolling */
   height: 100vh; /* Ensure full viewport height */
 }
+
+[data-radix-scroll-area-viewport] > div {
+  display: block !important;
+}


### PR DESCRIPTION
Bug where ChatLogs options was not visible 

This was caused when using the `@radix-ui/react-scroll-area component` and  automatically applying display: table to an inner div.

The simplest approach was to override with CSS 

```css
[data-radix-scroll-area-viewport] > div {
  display: block !important;
}
```