### PR TITLE
ChatLogs are mapped to their respective assistant

### DIFF
--- a/Client/package.json
+++ b/Client/package.json
@@ -78,5 +78,8 @@
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.3",
     "vite": "^5.2.0"
+  },
+  "resolutions": {
+    "@types/eslint": "8.4.3"
   }
 }

--- a/Client/src/components/chat/ChatInput.tsx
+++ b/Client/src/components/chat/ChatInput.tsx
@@ -14,6 +14,7 @@ import {
 import { v4 as uuidv4 } from "uuid";
 import { Button } from "../ui/button";
 import useTrackAnalytics from "@/hooks/useTrackAnalytics";
+import createLogTitle from "@/redux/log/crudLog";
 
 type ChatInputProps = {
   messagesContainerRef: React.RefObject<HTMLDivElement>;
@@ -118,11 +119,14 @@ const ChatInput = ({
 
       if (isNewChat) {
         dispatch(messageActions.toggleNewChat(false));
+        const logTitle = await createLogTitle(msg, currentModel.title);
+
         dispatch(
           logActions.addLog({
             msg,
-            modelTitle: currentModel.title,
+            logTitle: logTitle ? logTitle : "New Chat Log",
             id: newLogId,
+            assistantMongoId: currentModel.id,
           })
         )
           .unwrap()

--- a/Client/src/components/chat/NewChat.tsx
+++ b/Client/src/components/chat/NewChat.tsx
@@ -1,9 +1,8 @@
 import { useNavigate } from "react-router-dom";
 import { RiChatNewFill } from "react-icons/ri";
-
+import { onNewChat } from "./helpers/newChatHandler";
 // Redux:
 import { useAppDispatch, useAppSelector } from "@/redux";
-import { messageActions } from "@/redux";
 
 const NewChat = () => {
   const navigate = useNavigate();
@@ -13,19 +12,11 @@ const NewChat = () => {
 
   const error = useAppSelector((state) => state.message.error); // Access the error state from Redux
 
-  const onNewChat = () => {
-    if (currentMsgList.length > 0) {
-      dispatch(messageActions.resetMsgList()); // Reset the MsgList
-      dispatch(messageActions.toggleNewChat(true)); // Flag indicating it's a new chat
-      if (error) {
-        dispatch(messageActions.clearError()); // Clear error when user starts typing
-      }
-    }
-    navigate(`/chat`);
-  };
-
   return (
-    <button onClick={onNewChat} className="text-lg hover:text-gray-300">
+    <button
+      onClick={() => onNewChat(currentMsgList, dispatch, navigate, error)}
+      className="text-lg hover:text-gray-300"
+    >
       <RiChatNewFill />
     </button>
   );

--- a/Client/src/components/chat/helpers/newChatHandler.ts
+++ b/Client/src/components/chat/helpers/newChatHandler.ts
@@ -1,0 +1,20 @@
+import { messageActions } from "@/redux";
+import { AppDispatch } from "@/redux/store";
+import { MessageObjType } from "@polylink/shared/types";
+import { NavigateFunction } from "react-router-dom";
+
+export const onNewChat = (
+  currentMsgList: MessageObjType[],
+  dispatch: AppDispatch,
+  navigate: NavigateFunction,
+  error: string | null
+) => {
+  if (currentMsgList.length > 0) {
+    dispatch(messageActions.resetMsgList()); // Reset the MsgList
+    dispatch(messageActions.toggleNewChat(true)); // Flag indicating it's a new chat
+    if (error) {
+      dispatch(messageActions.clearError()); // Clear error when user starts typing
+    }
+  }
+  navigate(`/chat`);
+};

--- a/Client/src/components/layout/ChatPage/ChatPageHeader.tsx
+++ b/Client/src/components/layout/ChatPage/ChatPageHeader.tsx
@@ -4,11 +4,22 @@ import NewChat from "../../chat/NewChat";
 import { AssistantType } from "@polylink/shared/types";
 import { BiChat } from "react-icons/bi";
 // Redux:
-import { useAppDispatch, assistantActions, layoutActions } from "@/redux";
+import {
+  useAppDispatch,
+  assistantActions,
+  layoutActions,
+  useAppSelector,
+} from "@/redux";
+import { onNewChat } from "@/components/chat/helpers/newChatHandler";
+import { useNavigate } from "react-router-dom";
 
 const ChatHeader = () => {
   // Redux:
   const dispatch = useAppDispatch();
+  const currentMsgList = useAppSelector((state) => state.message.msgList);
+  const error = useAppSelector((state) => state.message.error);
+  const navigate = useNavigate();
+
   const { toggleSidebar } = useSidebar();
 
   const handleModeSelection = (model: AssistantType) => {
@@ -16,6 +27,7 @@ const ChatHeader = () => {
       const modelId = model.id;
       dispatch(assistantActions.setCurrentAssistant(modelId));
       dispatch(layoutActions.toggleDropdown(false));
+      onNewChat(currentMsgList, dispatch, navigate, error);
     }
   };
 

--- a/Client/src/pages/ChatPage.tsx
+++ b/Client/src/pages/ChatPage.tsx
@@ -56,6 +56,11 @@ const ChatPage = () => {
             dispatch(messageActions.setMsgList(log.content));
           }
           dispatch(messageActions.setCurrentChatId(chatId));
+          if (log.assistantMongoId) {
+            dispatch(
+              assistantActions.setCurrentAssistant(log.assistantMongoId)
+            );
+          }
         } catch (error) {
           console.error("Error fetching log: ", error);
         }

--- a/Client/src/redux/log/logSlice.ts
+++ b/Client/src/redux/log/logSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice, createAsyncThunk, PayloadAction } from "@reduxjs/toolkit";
-import createLogTitle, {
+import {
   createLogItem,
   fetchAllLogs,
   updateLogItem,
@@ -11,18 +11,18 @@ import { RootState } from "../store";
 
 export type AddLogParams = {
   msg: string;
-  modelTitle: string;
+  logTitle: string;
   id: string;
+  assistantMongoId: string;
 };
 // Thunk for adding a new log. Combines CREATE and READ operations.
 export const addLog = createAsyncThunk(
   "log/addLog",
   async (
-    { msg, modelTitle, id }: AddLogParams,
+    { logTitle, id, assistantMongoId }: AddLogParams,
     { dispatch, getState, rejectWithValue }
   ) => {
     try {
-      const logTitle = await createLogTitle(msg, modelTitle);
       const timestamp = new Date().toISOString(); // Timestamp for log
       const content = (getState() as RootState).message.msgList; // Accessing message list from the state
 
@@ -42,6 +42,7 @@ export const addLog = createAsyncThunk(
         logId: id,
         timestamp: timestamp, // Ensure the timestamp is included in the DB save
         title: logTitle,
+        assistantMongoId: assistantMongoId,
       });
       return { success: true, logId: id };
     } catch (error) {

--- a/server/src/db/models/chatlog/chatLogCollection.ts
+++ b/server/src/db/models/chatlog/chatLogCollection.ts
@@ -60,7 +60,15 @@ export const fetchLogById = async (
   try {
     const log = await chatLogCollection.findOne(
       { logId: logId },
-      { projection: { _id: 0, logId: 1, content: 1, userId: 1 } }
+      {
+        projection: {
+          _id: 0,
+          logId: 1,
+          content: 1,
+          userId: 1,
+          assistantMongoId: 1,
+        },
+      }
     );
 
     if (!log) {

--- a/server/src/helpers/assistants/multiAgent.ts
+++ b/server/src/helpers/assistants/multiAgent.ts
@@ -76,6 +76,7 @@ async function handleMultiAgentModel({
     runningStreams[userMessageId].threadId = threadId;
     // Parse the helper assistant's response (assumes it's a JSON string)
     let jsonObject;
+    // TO-DO: How to always ensure that the response is a JSON object?
     try {
       jsonObject = JSON.parse(helperResponse);
     } catch (error) {

--- a/server/src/routes/chatLog.ts
+++ b/server/src/routes/chatLog.ts
@@ -20,10 +20,11 @@ router.post("/", (async (req, res) => {
     if (!userId) {
       return res.status(401).json({ message: "Unauthorized" });
     }
-    const { logId, title, content, timestamp } = req.body;
+    const { assistantMongoId, logId, title, content, timestamp } = req.body;
 
     const newLog: ChatLogDocument = {
       logId,
+      assistantMongoId,
       title,
       timestamp,
       content,

--- a/shared/src/types/log/index.ts
+++ b/shared/src/types/log/index.ts
@@ -6,7 +6,7 @@ export type ChatLogDocument = LogData & {
 };
 
 export type LogData = {
-  assistantId?: string; // The assistantId from the assistant that the user is chatting with
+  assistantMongoId?: string; // The assistantId from the assistant that the user is chatting with
   content: MessageObjType[]; // The message content from the log
   logId: string; // The unique id associated with the chat log
   timestamp: string; // The timee the last message was sent on that chatLog


### PR DESCRIPTION
## Previous Application 

- Previously, our application allowed users to use the same chatlog and switch around multiple assistants
- To make things less complicated for the thread, I decided to tie the assistant with the chatlog

## New changes

- Assistant Ids are now stored with the chat log
- Selecting a new assistant makes a new chat
- Selecting a Chat Log updates assistant to the chat log's assistantMongoId

## Next Steps

- In the previous commit, I removed the feature for files
- We can still implement this for specific assistants but did not see a need for it as of right now.
- In the threads collection I will add the assistantMongoId and make vectorStoreId optional and only necessary if the student is using an assistant that allows for file uploads. 