### PR TITLE
New ThreadData Type

### DIFF
--- a/server/src/db/models/threads/threadCollection.ts
+++ b/server/src/db/models/threads/threadCollection.ts
@@ -1,5 +1,5 @@
 import { getDb } from "../../connection.js";
-import { Collection, InsertOneResult, ObjectId } from "mongodb";
+import { Collection, InsertOneResult } from "mongodb";
 import { ThreadDocument } from "@polylink/shared/types";
 
 let threadCollection: Collection<ThreadDocument>;
@@ -12,17 +12,18 @@ const initializeCollection = (): void => {
 export const createThread = async (
   chatId: string,
   threadId: string,
-  vectorStoreId: string
+  vectorStoreId: string | null,
+  assistantId: string
 ): Promise<InsertOneResult<ThreadDocument>> => {
   if (!threadCollection) initializeCollection();
 
   try {
     const newThread = {
-      _id: chatId as unknown as ObjectId, // TODO: FIX So we add the chatId as a new property and let mongoDB handle the ID ?
+      _id: chatId, // TODO: FIX So we add the chatId as a new property and let mongoDB handle the ID ?
       threadId,
       vectorStoreId,
+      assistantId,
     };
-
     const result = await threadCollection.insertOne(newThread);
     return result;
   } catch (error) {
@@ -38,13 +39,14 @@ export const getIds = async (
 
   try {
     const thread = await threadCollection.findOne({
-      _id: chatId as unknown as ObjectId,
+      _id: chatId,
     });
     if (!thread) return null;
     return {
       _id: thread._id,
       threadId: thread.threadId,
       vectorStoreId: thread.vectorStoreId,
+      assistantId: thread.assistantId,
     };
   } catch (error) {
     throw new Error("Error retrieving threadID: " + (error as Error).message);

--- a/server/src/db/models/threads/threadServices.ts
+++ b/server/src/db/models/threads/threadServices.ts
@@ -1,15 +1,18 @@
+import { ThreadData } from "@polylink/shared/types";
 import * as ThreadModel from "./threadCollection";
 // Confirming the structure in threadServices.js after adding a thread
 export const addThreadToDB = async (
   chatId: string,
   threadId: string,
-  vectorStoreId: string
+  vectorStoreId: string | null,
+  assistantId: string
 ): Promise<{ message: string; threadId: string }> => {
   try {
     const result = await ThreadModel.createThread(
       chatId,
       threadId,
-      vectorStoreId
+      vectorStoreId,
+      assistantId
     );
     return {
       message: "Thread created successfully",
@@ -22,13 +25,15 @@ export const addThreadToDB = async (
 };
 
 // Read
-export const fetchIds = async (
-  chatId: string
-): Promise<{ threadId: string; vectorStoreId: string } | null> => {
+export const fetchIds = async (chatId: string): Promise<ThreadData | null> => {
   try {
     const ids = await ThreadModel.getIds(chatId);
     if (!ids) return null;
-    return { threadId: ids.threadId, vectorStoreId: ids.vectorStoreId };
+    return {
+      threadId: ids.threadId,
+      vectorStoreId: ids.vectorStoreId,
+      assistantId: ids.assistantId,
+    };
   } catch (error) {
     console.error("No thread found: ", (error as Error).message);
     return null;

--- a/server/src/helpers/assistants/multiAgent.ts
+++ b/server/src/helpers/assistants/multiAgent.ts
@@ -63,7 +63,7 @@ async function handleMultiAgentModel({
     await openai.beta.threads.del(helperThread.id);
     // Set the main thread ID
     // Create thread and vector store if not already created
-    const { threadId } = await initializeOrFetchIds(chatId);
+    const { threadId } = await initializeOrFetchIds(chatId, null, model.id);
     // Setup assistant
     const assistant = await getAssistantById(model.id);
     if (!assistant) {

--- a/server/src/helpers/assistants/singleAgent.ts
+++ b/server/src/helpers/assistants/singleAgent.ts
@@ -93,12 +93,16 @@ async function handleSingleAgentModel({
     throw new Error("Assistant ID not found");
   }
   // Creates from OpenAI API & Stores in DB if not already created
-  const { threadId, vectorStoreId } = await initializeOrFetchIds(chatId);
+  const { threadId, vectorStoreId } = await initializeOrFetchIds(
+    chatId,
+    userFile ? userFile.id : null,
+    model.id
+  );
   // Add threadId to runningStreams
   runningStreams[userMessageId].threadId = threadId;
 
   // Setup vector store and update assistant
-  if (userFile) {
+  if (userFile && vectorStoreId) {
     await setupVectorStoreAndUpdateAssistant(
       vectorStoreId,
       assistantId,

--- a/shared/src/types/thread/index.ts
+++ b/shared/src/types/thread/index.ts
@@ -1,13 +1,9 @@
-import { ObjectId } from "mongodb";
-
 export type ThreadData = {
-  chatId: string;
   threadId: string;
-  vectorStoreId: string;
+  vectorStoreId: string | null;
+  assistantId?: string; // TO-DO: Eventually make this required (only optional for now for backwards compatibility)
 };
 
-export type ThreadDocument = {
-  _id: ObjectId;
-  threadId: string;
-  vectorStoreId: string;
+export type ThreadDocument = ThreadData & {
+  _id: string;
 };


### PR DESCRIPTION
# New Thread Data Type

```typescript
export type ThreadData = {
  threadId: string;
  vectorStoreId: string | null;
  assistantId?: string; // TO-DO: Eventually make this required (only optional for now for backwards compatibility)
};

export type ThreadDocument = ThreadData & {
  _id: string;
};

```

## Changes

### vectorStoreId 

- vectorStoreId is `null` if the assistant does not allow for matching, then the vectorStoreId is null
- This also prevents vectorStoreIds from being created using openAI API

### assistantId

- Added `assistantId`
- Currently optional but will make it mandatory once I refresh the database with a clean slate before deployment