### PR TITLE
# MessageList Approach

### DIFF
--- a/Client/src/components/chat/ChatContainer.tsx
+++ b/Client/src/components/chat/ChatContainer.tsx
@@ -19,7 +19,7 @@ const ChatContainer = () => {
     if (currentChatId && messagesByChatId[currentChatId]) {
       setMsgList(messagesByChatId[currentChatId].content);
     }
-  }, [messagesByChatId, currentChatId, msgList]);
+  }, [messagesByChatId, currentChatId]);
 
   useEffect(() => {
     const messagesContainer = messagesContainerRef.current;

--- a/Client/src/components/chat/ChatContainer.tsx
+++ b/Client/src/components/chat/ChatContainer.tsx
@@ -1,18 +1,25 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { ChatInput, ChatMessage } from "@/components/chat";
 import AssistantSuggestedMessages from "./AssistantSuggestedMessages";
 // Redux:
 import { useAppSelector } from "@/redux";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { MessageObjType } from "@polylink/shared/types";
 
 const ChatContainer = () => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const sendButtonRef = useRef<HTMLButtonElement>(null);
-  const { msgList, isNewChat, isLoading } = useAppSelector(
-    (state) => state.message
-  );
+  const { messagesByChatId, isNewChat, isLoading, currentChatId } =
+    useAppSelector((state) => state.message);
+  const [msgList, setMsgList] = useState<MessageObjType[]>([]);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
   const isUserAtBottomRef = useRef(true);
+
+  useEffect(() => {
+    if (currentChatId && messagesByChatId[currentChatId]) {
+      setMsgList(messagesByChatId[currentChatId].content);
+    }
+  }, [messagesByChatId, currentChatId, msgList]);
 
   useEffect(() => {
     const messagesContainer = messagesContainerRef.current;

--- a/Client/src/components/chat/ChatContainer.tsx
+++ b/Client/src/components/chat/ChatContainer.tsx
@@ -9,7 +9,7 @@ import { MessageObjType } from "@polylink/shared/types";
 const ChatContainer = () => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const sendButtonRef = useRef<HTMLButtonElement>(null);
-  const { messagesByChatId, isNewChat, isLoading, currentChatId } =
+  const { messagesByChatId, isNewChat, loading, currentChatId } =
     useAppSelector((state) => state.message);
   const [msgList, setMsgList] = useState<MessageObjType[]>([]);
   const messagesContainerRef = useRef<HTMLDivElement>(null);
@@ -54,7 +54,7 @@ const ChatContainer = () => {
 
   return (
     <div className="flex flex-col h-screen justify-between bg-slate-900">
-      {isNewChat && !isLoading ? (
+      {isNewChat && !loading[currentChatId ?? ""] ? (
         <AssistantSuggestedMessages sendButtonRef={sendButtonRef} />
       ) : (
         <ScrollArea ref={messagesContainerRef}>

--- a/Client/src/components/chat/ChatInput.tsx
+++ b/Client/src/components/chat/ChatInput.tsx
@@ -99,7 +99,8 @@ const ChatInput = ({
             currentModel,
             file: selectedFile, //add pdf file
             msg,
-            currentChatId: isNewChat ? newLogId : currentChatId,
+            currentChatId:
+              isNewChat || !currentChatId ? newLogId : currentChatId,
             userId: userId ? userId : "",
             userMessageId,
             botMessageId,
@@ -132,6 +133,7 @@ const ChatInput = ({
             logTitle: logTitle ? logTitle : "New Chat Log",
             id: newLogId,
             assistantMongoId: currentModel.id,
+            chatId: newLogId,
           })
         )
           .unwrap()
@@ -146,6 +148,7 @@ const ChatInput = ({
               logId: currentChatId,
               firebaseUserId: userId ? userId : null,
               urlPhoto: currentModel.urlPhoto,
+              chatId: currentChatId,
             })
           );
         }

--- a/Client/src/components/chat/ChatInput.tsx
+++ b/Client/src/components/chat/ChatInput.tsx
@@ -92,6 +92,11 @@ const ChatInput = ({
     }
     try {
       setSelectedFile(null);
+      const logId = isNewChat ? newLogId : currentChatId;
+      dispatch(messageActions.setCurrentChatId(logId));
+      if (!logId) {
+        throw new Error("Log ID is required");
+      }
 
       try {
         await dispatch(
@@ -99,8 +104,7 @@ const ChatInput = ({
             currentModel,
             file: selectedFile, //add pdf file
             msg,
-            currentChatId:
-              isNewChat || !currentChatId ? newLogId : currentChatId,
+            currentChatId: logId,
             userId: userId ? userId : "",
             userMessageId,
             botMessageId,
@@ -133,7 +137,7 @@ const ChatInput = ({
             logTitle: logTitle ? logTitle : "New Chat Log",
             id: newLogId,
             assistantMongoId: currentModel.id,
-            chatId: newLogId,
+            chatId: logId,
           })
         )
           .unwrap()

--- a/Client/src/components/chat/ChatInput.tsx
+++ b/Client/src/components/chat/ChatInput.tsx
@@ -33,7 +33,7 @@ const ChatInput = ({
     string | null
   >(null);
   const currentModel = useAppSelector((state) => state.assistant.currentModel);
-  const { msg, isNewChat, currentChatId, isLoading, error } = useAppSelector(
+  const { msg, isNewChat, currentChatId, loading, error } = useAppSelector(
     (state) => state.message
   );
   const userId = useAppSelector((state) => state.auth.userId);
@@ -173,9 +173,13 @@ const ChatInput = ({
 
   const handleStop = (e: { preventDefault: () => void }) => {
     e.preventDefault();
-
-    if (currentUserMessageId) {
-      dispatch(messageActions.cancelBotResponse(currentUserMessageId));
+    if (currentUserMessageId && currentChatId) {
+      dispatch(
+        messageActions.cancelBotResponse({
+          userMessageId: currentUserMessageId,
+          chatId: currentChatId,
+        })
+      );
     }
   };
 
@@ -193,7 +197,9 @@ const ChatInput = ({
         </div>
       )}
       <form
-        onSubmit={isLoading ? () => {} : handleSubmit}
+        onSubmit={
+          currentChatId && loading[currentChatId] ? () => {} : handleSubmit
+        }
         className="flex items-end gap-2"
       >
         {currentModel.title === "Will NOT Allow File Uploads for right now" && (
@@ -212,7 +218,7 @@ const ChatInput = ({
           maxLength={2000}
           onChange={handleInputChange}
         />
-        {isLoading ? (
+        {currentChatId && loading[currentChatId] ? (
           <Button
             className="dark:bg-transparent hover:bg-gray-800 dark:hover:bg-slate-800 focus:ring-2 focus:ring-red-400 focus:outline-none transition-all duration-300 ease-in-out px-4 py-2 text-base text-white"
             type="submit"
@@ -227,7 +233,9 @@ const ChatInput = ({
             className="bg-gradient-to-r from-blue-600 to-indigo-800 hover:from-blue-700 hover:to-indigo-900 focus:ring-2 focus:ring-blue-400 focus:outline-none transition-all duration-300 ease-in-out px-4 py-2 text-base"
             type="submit"
             variant="outline"
-            disabled={isLoading || msg.length === 0}
+            disabled={
+              currentChatId && loading[currentChatId] ? true : msg.length === 0
+            }
             ref={sendButtonRef}
           >
             <IoSend className="text-2xl" />

--- a/Client/src/components/chat/NewChat.tsx
+++ b/Client/src/components/chat/NewChat.tsx
@@ -3,18 +3,15 @@ import { RiChatNewFill } from "react-icons/ri";
 import { onNewChat } from "./helpers/newChatHandler";
 // Redux:
 import { useAppDispatch, useAppSelector } from "@/redux";
-
 const NewChat = () => {
   const navigate = useNavigate();
   // Redux:
   const dispatch = useAppDispatch();
-  const currentMsgList = useAppSelector((state) => state.message.msgList);
-
-  const error = useAppSelector((state) => state.message.error); // Access the error state from Redux
+  const { currentChatId, error } = useAppSelector((state) => state.message);
 
   return (
     <button
-      onClick={() => onNewChat(currentMsgList, dispatch, navigate, error)}
+      onClick={() => onNewChat(currentChatId, dispatch, navigate, error)}
       className="text-lg hover:text-gray-300"
     >
       <RiChatNewFill />

--- a/Client/src/components/chat/NewChat.tsx
+++ b/Client/src/components/chat/NewChat.tsx
@@ -7,11 +7,22 @@ const NewChat = () => {
   const navigate = useNavigate();
   // Redux:
   const dispatch = useAppDispatch();
-  const { currentChatId, error } = useAppSelector((state) => state.message);
+  const { currentChatId, error, loading, messagesByChatId } = useAppSelector(
+    (state) => state.message
+  );
 
   return (
     <button
-      onClick={() => onNewChat(currentChatId, dispatch, navigate, error)}
+      onClick={() =>
+        onNewChat(
+          currentChatId,
+          dispatch,
+          navigate,
+          error,
+          loading,
+          messagesByChatId
+        )
+      }
       className="text-lg hover:text-gray-300"
     >
       <RiChatNewFill />

--- a/Client/src/components/chat/helpers/newChatHandler.ts
+++ b/Client/src/components/chat/helpers/newChatHandler.ts
@@ -9,11 +9,15 @@ export const onNewChat = (
   error: string | null
 ) => {
   if (currentChatId) {
-    dispatch(messageActions.resetMsgList(currentChatId)); // Reset the MsgList
+    console.log("currentChatId", currentChatId);
+    dispatch(messageActions.setCurrentChatId(null));
+
     if (error) {
       dispatch(messageActions.clearError()); // Clear error when user starts typing
     }
+    dispatch(messageActions.setCurrentChatId(null));
   }
+
   dispatch(messageActions.toggleNewChat(true)); // Flag indicating it's a new chat
   navigate(`/chat`);
 };

--- a/Client/src/components/chat/helpers/newChatHandler.ts
+++ b/Client/src/components/chat/helpers/newChatHandler.ts
@@ -1,20 +1,19 @@
 import { messageActions } from "@/redux";
 import { AppDispatch } from "@/redux/store";
-import { MessageObjType } from "@polylink/shared/types";
 import { NavigateFunction } from "react-router-dom";
 
 export const onNewChat = (
-  currentMsgList: MessageObjType[],
+  currentChatId: string | null,
   dispatch: AppDispatch,
   navigate: NavigateFunction,
   error: string | null
 ) => {
-  if (currentMsgList.length > 0) {
-    dispatch(messageActions.resetMsgList()); // Reset the MsgList
-    dispatch(messageActions.toggleNewChat(true)); // Flag indicating it's a new chat
+  if (currentChatId) {
+    dispatch(messageActions.resetMsgList(currentChatId)); // Reset the MsgList
     if (error) {
       dispatch(messageActions.clearError()); // Clear error when user starts typing
     }
   }
+  dispatch(messageActions.toggleNewChat(true)); // Flag indicating it's a new chat
   navigate(`/chat`);
 };

--- a/Client/src/components/chat/helpers/newChatHandler.ts
+++ b/Client/src/components/chat/helpers/newChatHandler.ts
@@ -1,15 +1,32 @@
 import { messageActions } from "@/redux";
 import { AppDispatch } from "@/redux/store";
 import { NavigateFunction } from "react-router-dom";
+import { MessageByChatIdType } from "@polylink/shared/types";
 
 export const onNewChat = (
   currentChatId: string | null,
   dispatch: AppDispatch,
   navigate: NavigateFunction,
-  error: string | null
+  error: string | null,
+  loading: { [chatId: string]: boolean },
+  messagesByChatId: MessageByChatIdType
 ) => {
   if (currentChatId) {
-    console.log("currentChatId", currentChatId);
+    if (loading[currentChatId]) {
+      // Get the last user message id. It will be the last or 2nd to last message in the array. it will always be the the last message of the array with the type "user"
+      const lastMessages = messagesByChatId[currentChatId].content.slice(-2);
+      const userMessageId = lastMessages.find(
+        (message) => message.sender === "user"
+      )?.id;
+      if (userMessageId) {
+        dispatch(
+          messageActions.cancelBotResponse({
+            userMessageId: userMessageId,
+            chatId: currentChatId,
+          })
+        );
+      }
+    }
     dispatch(messageActions.setCurrentChatId(null));
 
     if (error) {

--- a/Client/src/components/chatLog/ChatLogOptions.tsx
+++ b/Client/src/components/chatLog/ChatLogOptions.tsx
@@ -51,6 +51,7 @@ const ChatLogOptions = ({
             navigate(`/chat`);
             dispatch(messageActions.resetMsgList(log.logId));
             dispatch(messageActions.toggleNewChat(true));
+            dispatch(messageActions.setCurrentChatId(null));
           })
           .catch((error) => {
             if (environment === "dev") {

--- a/Client/src/components/chatLog/ChatLogOptions.tsx
+++ b/Client/src/components/chatLog/ChatLogOptions.tsx
@@ -49,7 +49,7 @@ const ChatLogOptions = ({
           .unwrap()
           .then(() => {
             navigate(`/chat`);
-            dispatch(messageActions.resetMsgList());
+            dispatch(messageActions.resetMsgList(log.logId));
             dispatch(messageActions.toggleNewChat(true));
           })
           .catch((error) => {

--- a/Client/src/components/layout/ChatPage/ChatPageHeader.tsx
+++ b/Client/src/components/layout/ChatPage/ChatPageHeader.tsx
@@ -24,7 +24,7 @@ const ChatHeader = () => {
   const { toggleSidebar } = useSidebar();
 
   const handleModeSelection = (model: AssistantType) => {
-    if (model && model.id && currentChatId) {
+    if (model && model.id) {
       const modelId = model.id;
       dispatch(assistantActions.setCurrentAssistant(modelId));
       dispatch(layoutActions.toggleDropdown(false));

--- a/Client/src/components/layout/ChatPage/ChatPageHeader.tsx
+++ b/Client/src/components/layout/ChatPage/ChatPageHeader.tsx
@@ -16,7 +16,9 @@ import { useNavigate } from "react-router-dom";
 const ChatHeader = () => {
   // Redux:
   const dispatch = useAppDispatch();
-  const { currentChatId } = useAppSelector((state) => state.message);
+  const { currentChatId, loading, messagesByChatId } = useAppSelector(
+    (state) => state.message
+  );
 
   const error = useAppSelector((state) => state.message.error);
   const navigate = useNavigate();
@@ -28,7 +30,14 @@ const ChatHeader = () => {
       const modelId = model.id;
       dispatch(assistantActions.setCurrentAssistant(modelId));
       dispatch(layoutActions.toggleDropdown(false));
-      onNewChat(currentChatId, dispatch, navigate, error);
+      onNewChat(
+        currentChatId,
+        dispatch,
+        navigate,
+        error,
+        loading,
+        messagesByChatId
+      );
     }
   };
 

--- a/Client/src/components/layout/ChatPage/ChatPageHeader.tsx
+++ b/Client/src/components/layout/ChatPage/ChatPageHeader.tsx
@@ -16,18 +16,19 @@ import { useNavigate } from "react-router-dom";
 const ChatHeader = () => {
   // Redux:
   const dispatch = useAppDispatch();
-  const currentMsgList = useAppSelector((state) => state.message.msgList);
+  const { currentChatId } = useAppSelector((state) => state.message);
+
   const error = useAppSelector((state) => state.message.error);
   const navigate = useNavigate();
 
   const { toggleSidebar } = useSidebar();
 
   const handleModeSelection = (model: AssistantType) => {
-    if (model && model.id) {
+    if (model && model.id && currentChatId) {
       const modelId = model.id;
       dispatch(assistantActions.setCurrentAssistant(modelId));
       dispatch(layoutActions.toggleDropdown(false));
-      onNewChat(currentMsgList, dispatch, navigate, error);
+      onNewChat(currentChatId, dispatch, navigate, error);
     }
   };
 

--- a/Client/src/components/layout/ChatPage/ChatPageSidebar.tsx
+++ b/Client/src/components/layout/ChatPage/ChatPageSidebar.tsx
@@ -24,10 +24,30 @@ export function ChatPageSidebar() {
   const dispatch = useAppDispatch();
   const logList = useAppSelector((state) => state.log.logList);
   const userId = useAppSelector((state) => state.auth.userId);
+  const { currentChatId, loading, messagesByChatId } = useAppSelector(
+    (state) => state.message
+  );
   const hasFetchedLogs = useRef(false);
 
   // Handler for selecting a log to view
   const handleSelectLog = (logId: string) => {
+    if (currentChatId) {
+      if (loading[currentChatId]) {
+        // Get the last user message id. It will be the last or 2nd to last message in the array. it will always be the the last message of the array with the type "user"
+        const lastMessages = messagesByChatId[currentChatId].content.slice(-2);
+        const userMessageId = lastMessages.find(
+          (message) => message.sender === "user"
+        )?.id;
+        if (userMessageId) {
+          dispatch(
+            messageActions.cancelBotResponse({
+              userMessageId: userMessageId,
+              chatId: currentChatId,
+            })
+          );
+        }
+      }
+    }
     const chosenLog = logList.find((item) => item.logId === logId);
     if (chosenLog) {
       // Set the current chat id

--- a/Client/src/pages/ChatPage.tsx
+++ b/Client/src/pages/ChatPage.tsx
@@ -56,7 +56,9 @@ const ChatPage = () => {
         try {
           const log = (await fetchLogById(chatId)) as LogData;
           if (log.content) {
-            dispatch(messageActions.setMsgList(log.content));
+            dispatch(
+              messageActions.setMsgList({ chatId, content: log.content })
+            );
           }
           dispatch(messageActions.setCurrentChatId(chatId));
           if (log.assistantMongoId) {

--- a/Client/src/pages/ChatPage.tsx
+++ b/Client/src/pages/ChatPage.tsx
@@ -19,7 +19,6 @@ const ChatPage = () => {
   const { chatId } = useParams();
 
   const userId = useAppSelector((state) => state.auth.userId);
-
   const assistantList = useAppSelector(
     (state) => state.assistant.assistantList
   );
@@ -57,7 +56,11 @@ const ChatPage = () => {
           const log = (await fetchLogById(chatId)) as LogData;
           if (log.content) {
             dispatch(
-              messageActions.setMsgList({ chatId, content: log.content })
+              messageActions.setMsgList({
+                chatId,
+                content: log.content,
+                assistantMongoId: log.assistantMongoId || "",
+              })
             );
           }
           dispatch(messageActions.setCurrentChatId(chatId));

--- a/Client/src/redux/message/messageSlice.ts
+++ b/Client/src/redux/message/messageSlice.ts
@@ -44,7 +44,6 @@ export const fetchBotResponse = createAsyncThunk<
     }: fetchBotResponseParams,
     { dispatch, rejectWithValue }
   ) => {
-    console.log("currentChatId", currentChatId);
     try {
       const newUserMessage = {
         id: userMessageId,
@@ -83,8 +82,7 @@ export const fetchBotResponse = createAsyncThunk<
           },
           assistantMongoId: currentModel.id,
         })
-      ); // Dispatching to add bot message to the state
-
+      ); // Dispatching to add bot message to the state)
       const { botMessage, updateStream }: SendMessageReturnType =
         await sendMessage(
           currentModel,
@@ -255,7 +253,6 @@ const messageSlice = createSlice({
       if (!state.messagesByChatId[chatId]) {
         throw new Error("Chat log not found");
       }
-
       state.messagesByChatId[chatId] = {
         content: [...state.messagesByChatId[chatId].content, content],
         assistantMongoId: assistantMongoId,
@@ -314,21 +311,22 @@ const messageSlice = createSlice({
     // Reducer to set the entire message list (typically for initial load e.g. when a user selects a new log or new chat) (UPDATE)
     setMsgList: (
       state,
-      action: PayloadAction<{ chatId: string; content: MessageObjType[] }>
+      action: PayloadAction<{
+        chatId: string;
+        content: MessageObjType[];
+        assistantMongoId: string;
+      }>
     ) => {
-      const { chatId, content } = action.payload;
+      const { chatId, content, assistantMongoId } = action.payload;
       state.messagesByChatId[chatId] = {
         content: content,
-        assistantMongoId: "",
+        assistantMongoId: assistantMongoId,
       };
     },
     // Reducer to clear the message list (DELETE)
     resetMsgList: (state, action: PayloadAction<string>) => {
       const chatId = action.payload;
-      state.messagesByChatId[chatId] = {
-        content: [],
-        assistantMongoId: "",
-      };
+      delete state.messagesByChatId[chatId];
     },
     updateError: (state, action: PayloadAction<string>) => {
       state.error = action.payload;
@@ -337,7 +335,7 @@ const messageSlice = createSlice({
     clearError: (state) => {
       state.error = null;
     },
-    setCurrentChatId(state, action: PayloadAction<string>) {
+    setCurrentChatId(state, action: PayloadAction<string | null>) {
       state.currentChatId = action.payload;
     },
     toggleNewChat(state, action: PayloadAction<boolean>) {

--- a/server/src/routes/chatLog.ts
+++ b/server/src/routes/chatLog.ts
@@ -22,7 +22,7 @@ router.post("/", (async (req, res) => {
       return res.status(401).json({ message: "Unauthorized" });
     }
     const { assistantMongoId, logId, title, content, timestamp } = req.body;
-    console.log("content: ", content);
+
     const newLog: ChatLogDocument = {
       logId,
       assistantMongoId,

--- a/server/src/routes/llm.ts
+++ b/server/src/routes/llm.ts
@@ -150,19 +150,21 @@ router.post(
           delete runningStreams[userMessageId];
           res.status(200).send("Run(s) cancelled");
         } catch (error: unknown) {
-          // const message = (error as { error: Error | null })?.error?.message;
-          // if (message?.includes("Cannot cancel run with status")) {
-          //   console.log("Run canceled");
-          // } else
-          // if (message?.includes("already has an active run")) {
-          //   console.log("Run already canceled: ", message);
-          //   // TO-DO: Edge case where the run is in the pending state of being created while the user cancels the run which makes it so that the run is not canceled
-          // } else {
-          if (environment === "dev") {
-            console.error("Error cancelling run(s):", error);
+          const message = (error as { error: Error | null })?.error?.message;
+          if (message?.includes("Cannot cancel run with status")) {
+            if (environment === "dev") {
+              console.log("Run canceled");
+            }
+          } else if (message?.includes("already has an active run")) {
+            if (environment === "dev") {
+              console.log("Run already canceled: ", message);
+            }
+          } else {
+            if (environment === "dev") {
+              console.error("Error cancelling run(s):", error);
+            }
+            res.status(500).send("Error cancelling run(s)");
           }
-          res.status(500).send("Error cancelling run(s)");
-          // }
         }
       } else {
         // `runId` not yet available; cancellation flag is set

--- a/shared/src/types/message/index.ts
+++ b/shared/src/types/message/index.ts
@@ -13,7 +13,12 @@ export interface MessageSliceType {
   currentChatId: string | null; // The log Id associated with the chat
   msg: string; // The current message being typed
   isNewChat: boolean; // If its a new chat or not
-  msgList: MessageObjType[]; // The entire list of messages associated with a chat log
+  messagesByChatId: {
+    [chatId: string]: {
+      content: MessageObjType[];
+      assistantMongoId: string;
+    } | null;
+  };
   isLoading: boolean; // If the message is currently being streamed out
   error: string | null; // The error for the chat message
 }

--- a/shared/src/types/message/index.ts
+++ b/shared/src/types/message/index.ts
@@ -8,17 +8,20 @@ export type MessageObjType = {
   thinkingState?: boolean;
 };
 
+export type MessageByChatIdType = {
+  [chatId: string]: {
+    content: MessageObjType[];
+    assistantMongoId: string;
+  };
+};
 // Important:
 export interface MessageSliceType {
   currentChatId: string | null; // The log Id associated with the chat
   msg: string; // The current message being typed
   isNewChat: boolean; // If its a new chat or not
-  messagesByChatId: {
-    [chatId: string]: {
-      content: MessageObjType[];
-      assistantMongoId: string;
-    } | null;
+  messagesByChatId: MessageByChatIdType;
+  loading: {
+    [chatId: string]: boolean;
   };
-  isLoading: boolean; // If the message is currently being streamed out
   error: string | null; // The error for the chat message
 }


### PR DESCRIPTION
# New Approach for MsgList

- Previously, I had a redux state for the `msgList` which is all the messages of the chat log stored in state 
- I am changing this approach because there was a bug I caught

## The Bug 

- The bug occurred because I was updating the chatLog's content and setting it to our msgList
- However, the msgList depended on our current chatLog shown given the id from the url
- The case where this caused a bug is when a message was being streamed out and the user clicked onto another chatLog or made a new chat 

### Bug Effect

- This is an edge case, but the results would mean that the previous chat log that was clicked off would have its entire content erased and replaced

## Solution

- The solution was to `normalize` the chatId
- What i mean by this is storing fetched chatIds in state 
- I also am now keeping track of loading chatIds that are being streamed out and cancelling the run if the user clicks off 