### PR TITLE
added state to handle renaming

### DIFF
--- a/Client/src/components/flowchart/flowchartLog/FlowchartLogOptions.tsx
+++ b/Client/src/components/flowchart/flowchartLog/FlowchartLogOptions.tsx
@@ -25,8 +25,10 @@ const FlowchartLogOptions = ({
 }: {
   flowchart: FetchedFlowchartObject;
   name: string;
+  // eslint-disable-next-line no-unused-vars
   onNameChange: (name: string) => void;
   primaryOption: boolean;
+  // eslint-disable-next-line no-unused-vars
   onPrimaryChange: (primaryOption: boolean) => void;
 }) => {
   const { handleSave, handleChangeFlowchartInformation } = useUserData();


### PR DESCRIPTION
FLOWCHART:

previously, if we tried to rename a chat log and pressed save, the popover wouldn't actually disappear

same logic as chat page