### PR TITLE
Added new layout for mobile devices section page

### DIFF
--- a/Client/src/components/calendar/buildSchedule/layout/MobileBuildScheduleContainer.tsx
+++ b/Client/src/components/calendar/buildSchedule/layout/MobileBuildScheduleContainer.tsx
@@ -1,0 +1,29 @@
+import LeftSectionFooter from "./LeftScheduleFooter";
+
+const MobileBuildScheduleContainer = ({
+  children,
+  onFormSubmit,
+  onClick,
+}: {
+  children: React.ReactNode;
+  onFormSubmit: () => void;
+  onClick: () => void;
+}) => {
+  return (
+    <>
+      <div className="flex flex-col">
+        <div className="px-6 space-y-4 mb-48">{children}</div>
+      </div>
+      <footer className="safe-bottom-inset fixed bottom-0 w-full">
+        <LeftSectionFooter
+          formText="Apply Filters"
+          buttonText="Reset Filters"
+          onFormSubmit={onFormSubmit}
+          onClick={onClick}
+        />
+      </footer>
+    </>
+  );
+};
+
+export default MobileBuildScheduleContainer;

--- a/Client/src/components/layout/SectionPage/MobileSectionPageLayout.tsx
+++ b/Client/src/components/layout/SectionPage/MobileSectionPageLayout.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+// My components
+import MobileHeader from "@/components/layout/MobileHeader";
+
+type MobileSectionPageLayoutProps = {
+  children: React.ReactNode;
+};
+
+const MobileSectionPageLayout = ({
+  children,
+}: MobileSectionPageLayoutProps) => {
+  return (
+    <div
+      className="
+        flex flex-col 
+        min-h-screen 
+        bg-slate-900 
+        text-white 
+        w-full 
+        ml-0 
+        overflow-hidden 
+        overscroll-none 
+        touch-none
+      "
+      style={{
+        // Prevent default scrolling on the body
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+      }}
+    >
+      <MobileHeader />
+      <div
+        className="
+          flex-1 
+          overflow-y-auto 
+          no-scrollbar 
+          overscroll-contain
+        "
+        style={{
+          // Allow scrolling within this div while hiding scrollbars
+          WebkitOverflowScrolling: "touch",
+          scrollbarWidth: "none", // Firefox
+          msOverflowStyle: "none", // Internet Explorer/Edge
+        }}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default MobileSectionPageLayout;

--- a/Client/src/components/section/courseFilters/SectionForm.tsx
+++ b/Client/src/components/section/courseFilters/SectionForm.tsx
@@ -31,7 +31,8 @@ import {
 } from "@/components/section/courseFilters/helpers/constants";
 import { SECTION_FILTERS_SCHEMA } from "@/components/section/courseFilters/helpers/constants";
 import useIsMobile from "@/hooks/use-mobile";
-
+import useDeviceType from "@/hooks/useDeviceType";
+import MobileBuildScheduleContainer from "@/components/calendar/buildSchedule/layout/MobileBuildScheduleContainer";
 export type SectionFiltersForm = z.infer<typeof SECTION_FILTERS_SCHEMA>;
 
 const SectionForm = ({
@@ -42,6 +43,7 @@ const SectionForm = ({
 }) => {
   const dispatch = useAppDispatch();
   const isMobile = useIsMobile();
+  const deviceType = useDeviceType();
 
   const reduxFilters = useAppSelector((state) => state.section.filters);
   const { userData } = useUserData();
@@ -248,17 +250,28 @@ const SectionForm = ({
     <div>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
-          <BuildScheduleContainer>
-            <SectionFilters form={form} />
-          </BuildScheduleContainer>
-          <LeftSectionFooter
-            formText="Apply Filters"
-            buttonText="Reset Filters"
-            onFormSubmit={() => {
-              onSubmit(form.getValues());
-            }}
-            onClick={onFormReset}
-          />
+          {deviceType !== "desktop" ? (
+            <MobileBuildScheduleContainer
+              onFormSubmit={() => onSubmit(form.getValues())}
+              onClick={onFormReset}
+            >
+              <SectionFilters form={form} />
+            </MobileBuildScheduleContainer>
+          ) : (
+            <>
+              <BuildScheduleContainer>
+                <SectionFilters form={form} />
+              </BuildScheduleContainer>
+              <LeftSectionFooter
+                formText="Apply Filters"
+                buttonText="Reset Filters"
+                onFormSubmit={() => {
+                  onSubmit(form.getValues());
+                }}
+                onClick={onFormReset}
+              />
+            </>
+          )}
         </form>
       </Form>
     </div>

--- a/Client/src/hooks/useDeviceType.ts
+++ b/Client/src/hooks/useDeviceType.ts
@@ -1,0 +1,44 @@
+import { useState, useEffect } from "react";
+
+type DeviceType = "mobile" | "tablet" | "desktop";
+
+function detectDeviceType(): DeviceType {
+  // If `navigator` is unavailable (e.g., SSR), default to "desktop"
+  if (typeof navigator === "undefined") {
+    return "desktop";
+  }
+
+  const ua = navigator.userAgent.toLowerCase();
+  const { platform, maxTouchPoints } = navigator;
+
+  // iPad detection for iPadOS 13+
+  // iPad can appear as "MacIntel" with touch points > 1
+  const isIpad =
+    (platform === "MacIntel" && maxTouchPoints > 1) || /ipad/.test(ua);
+
+  // Phone detection
+  const isPhone = /mobi|android|iphone|ipod|windows phone/.test(ua);
+
+  // Tablet detection (additional patterns for e-readers/tablets if needed)
+  const isTablet = /tablet|playbook|silk/.test(ua) || isIpad;
+
+  if (isPhone) {
+    return "mobile";
+  } else if (isTablet) {
+    return "tablet";
+  }
+  return "desktop";
+}
+
+export default function useDeviceType(): DeviceType {
+  const [deviceType, setDeviceType] = useState<DeviceType>("desktop");
+
+  useEffect(() => {
+    setDeviceType(detectDeviceType());
+    // Since user agent or platform won't change during a session,
+    // no need to listen to `resize` unless you want additional
+    // logic that partially depends on width.
+  }, []);
+
+  return deviceType;
+}

--- a/Client/src/index.css
+++ b/Client/src/index.css
@@ -133,3 +133,13 @@ body {
 .fc-header-toolbar {
   margin-bottom: 0px !important;
 }
+/* Hide scrollbar for Chrome, Safari and Opera */
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
+/* Hide scrollbar for IE, Edge and Firefox */
+.no-scrollbar {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}

--- a/Client/src/pages/SectionPage.tsx
+++ b/Client/src/pages/SectionPage.tsx
@@ -8,27 +8,36 @@ import SectionForm from "@/components/section/courseFilters/SectionForm";
 // UI Components
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useState } from "react";
+import MobileSectionPageLayout from "@/components/layout/SectionPage/MobileSectionPageLayout";
+import useDeviceType from "@/hooks/useDeviceType";
 
 const SectionPage = () => {
   const isMobile = useMobile();
+  const deviceType = useDeviceType();
 
   return (
-    <SectionPageLayout>
-      {isMobile ? (
-        <SectionMobile />
+    <>
+      {deviceType !== "desktop" ? (
+        <MobileSectionPage />
       ) : (
-        <div>
-          <div className="grid grid-cols-1 md:grid-cols-3 grid-rows-1 gap-4">
-            <div className="col-span-1">
-              <SectionForm onSwitchTab={() => {}} />
+        <SectionPageLayout>
+          {isMobile ? (
+            <SectionMobile />
+          ) : (
+            <div>
+              <div className="grid grid-cols-1 md:grid-cols-3 grid-rows-1 gap-4">
+                <div className="col-span-1">
+                  <SectionForm onSwitchTab={() => {}} />
+                </div>
+                <div className="col-span-2">
+                  <SectionContainer />
+                </div>
+              </div>
             </div>
-            <div className="col-span-2">
-              <SectionContainer />
-            </div>
-          </div>
-        </div>
+          )}
+        </SectionPageLayout>
       )}
-    </SectionPageLayout>
+    </>
   );
 };
 
@@ -52,6 +61,31 @@ const SectionMobile = () => {
         <SectionContainer />
       </TabsContent>
     </Tabs>
+  );
+};
+
+const MobileSectionPage = () => {
+  const [tabValue, setTabValue] = useState("filters");
+
+  return (
+    <MobileSectionPageLayout>
+      <Tabs
+        value={tabValue}
+        onValueChange={(value) => setTabValue(value)}
+        defaultValue="filters"
+      >
+        <TabsList className="grid w-full grid-cols-2 dark:bg-gray-900">
+          <TabsTrigger value="filters">Filters</TabsTrigger>
+          <TabsTrigger value="sections">View Sections</TabsTrigger>
+        </TabsList>
+        <TabsContent value="filters">
+          <SectionForm onSwitchTab={() => setTabValue("sections")} />
+        </TabsContent>
+        <TabsContent value="sections">
+          <SectionContainer />
+        </TabsContent>
+      </Tabs>
+    </MobileSectionPageLayout>
   );
 };
 

--- a/Client/tailwind.config.js
+++ b/Client/tailwind.config.js
@@ -14,7 +14,7 @@ export default {
     },
     extend: {
       fontSize: {
-        xxs: "10px"
+        xxs: "10px",
       },
       boxShadow: {
         input:
@@ -59,7 +59,25 @@ export default {
       },
     },
   },
-  plugins: [typography, require("tailwindcss-animate"), addVariablesForColors],
+  plugins: [
+    typography,
+    require("tailwindcss-animate"),
+    addVariablesForColors,
+    function ({ addUtilities }) {
+      addUtilities({
+        ".safe-bottom-inset": {
+          "padding-bottom": "16px",
+          "padding-bottom": "calc(16px + env(safe-area-inset-bottom))",
+          "padding-bottom": "calc(16px + constant(safe-area-inset-bottom))",
+        },
+        ".safe-top-inset": {
+          "padding-top": "16px",
+          "padding-top": "calc(16px + env(safe-area-inset-top))",
+          "padding-top": "calc(16px + constant(safe-area-inset-top))",
+        },
+      });
+    },
+  ],
 };
 
 function addVariablesForColors({ addBase, theme }) {


### PR DESCRIPTION
## 📌 Summary

- Modified the mobile layout for sections so that the `Apply Filters` button is no longer hidden

## 🔍 Related Issues

- Closes #213 

## ✅ Checklist

- [X] My code follows the **PolyLink Contribution Guidelines**.
- [x] I have **tested my changes** to ensure they work as expected.
- [x] I have **documented my changes** (if applicable).
- [x] My PR has **a clear title and description**.

## 🛠 Changes Made

<!-- Describe what changes were made in this PR -->

- I created a new custom hook to determine what device the user is on
- For mobile/tablet devices we will display a new layout for the section page
-

## ❓ Additional Notes

- As of right now, the naming convention of the components is a little confusing. As we have the `isMobile` hook which only checks the screen width.
- I will change this soon so that the naming makes more sense 
