### PR TITLE
[Bug-Mobile-Chat-Navigation]: Fix Chat Navigation for Small Width Devices

### DIFF
--- a/Client/src/components/layout/MobileHeader.tsx
+++ b/Client/src/components/layout/MobileHeader.tsx
@@ -1,6 +1,12 @@
 import { UserAvatar } from "@/components/userProfile/UserAvatar";
 import { useNavigate, useLocation } from "react-router-dom";
-import { useAppSelector } from "@/redux";
+import {
+  useAppSelector,
+  assistantActions,
+  sectionActions,
+  useAppDispatch,
+} from "@/redux";
+import { onNewChat } from "../chat/helpers/newChatHandler";
 
 // UI Components
 import { Button } from "@/components/ui/button";
@@ -16,18 +22,48 @@ import { FaCalendarAlt, FaSearch } from "react-icons/fa";
 import { HiOutlineAcademicCap } from "react-icons/hi2";
 
 function MobileHeader() {
+  const dispatch = useAppDispatch();
   const { userData } = useAppSelector((state) => state.user);
   const { currentChatId } = useAppSelector((state) => state.message);
   const { currentCalendar } = useAppSelector((state) => state.calendar);
+  const { error, loading, messagesByChatId } = useAppSelector(
+    (state) => state.message
+  );
+  const { assistantList } = useAppSelector((state) => state.assistant);
 
   const navigate = useNavigate();
   const location = useLocation();
 
+  const handleChatClick = () => {
+    dispatch(sectionActions.setIsInitialState(true));
+
+    if (assistantList.length > 0) {
+      dispatch(assistantActions.setCurrentAssistant(assistantList[0].id));
+    }
+
+    onNewChat(
+      currentChatId,
+      dispatch,
+      navigate,
+      error,
+      loading,
+      messagesByChatId
+    );
+
+    if (currentChatId) {
+      navigate(`/chat/${currentChatId}`);
+    } else {
+      navigate("/chat");
+    }
+  };
+
   const handleNavigation = (path: string) => {
+    dispatch(sectionActions.setIsInitialState(true));
+
     if (path === "/flowchart" && userData.flowchartInformation.flowchartId) {
       navigate(`/flowchart/${userData.flowchartInformation.flowchartId}`);
-    } else if (path === "/chat" && currentChatId) {
-      navigate(`/chat/${currentChatId}`);
+    } else if (path === "/chat") {
+      handleChatClick();
     } else if (path === "/calendar" && currentCalendar) {
       navigate(`/calendar/${currentCalendar.id}`);
     } else {


### PR DESCRIPTION
## 📌 Summary

Synchronized chat navigation logic between mobile header and sidebar components to ensure consistent assistant selection behavior across all screen sizes.

## 🔍 Related Issues

Closes #233 

## 🛠 Changes Made

- Added Redux dispatch and selector hooks to MobileHeader component
- Implemented `handleChatClick` function in MobileHeader to match OuterSidebar logic
- Added necessary imports for Redux actions and chat helper functions
- Updated chat navigation in MobileHeader to properly set initial state and default assistant
- Ensured consistent behavior for assistant selection across all screen sizes

## ✅ Checklist

- [x] My code follows the **PolyLink Contribution Guidelines**.
- [x] I have **tested my changes** to ensure they work as expected.
- [x] I have **documented my changes** (if applicable).
- [x] My PR has **a clear title and description**.

## 📸 Screenshots (if applicable)

## ❓ Additional Notes

This change ensures that the Cal Poly SLO Assistant (first assistant in the list) is always selected by default when navigating to the chat interface, regardless of screen size or navigation method. The fix maintains existing functionality while addressing the inconsistent assistant selection issue on mobile devices.