### PR TITLE
Refactor mobile detection hook: replace use-mobile with useIsNarrowScreen across components

### DIFF
--- a/Client/src/components/calendar/weeklyCalendar/layout/CalendarContainer.tsx
+++ b/Client/src/components/calendar/weeklyCalendar/layout/CalendarContainer.tsx
@@ -4,10 +4,10 @@ import {
   WeeklyCalendar,
 } from "@/components/calendar";
 import { useAppSelector } from "@/redux";
-import useIsMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 
 const CalendarContainer = () => {
-  const isMobile = useIsMobile();
+  const isMobile = useIsNarrowScreen();
   const { calendars, currentCalendar } = useAppSelector(
     (state) => state.calendar
   );

--- a/Client/src/components/chat/chatBody/ChatMessage.tsx
+++ b/Client/src/components/chat/chatBody/ChatMessage.tsx
@@ -8,7 +8,7 @@ import useTrackAnalytics from "@/hooks/useTrackAnalytics";
 import { putUserReaction } from "@/redux/message/messageSlice";
 import { useAppDispatch, useAppSelector } from "@/redux";
 import { Skeleton } from "@/components/ui/skeleton";
-import useMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 
 const md = new MarkdownIt();
 
@@ -35,7 +35,7 @@ const ChatMessage = ({ msg }: ChatMessageProps) => {
   const dispatch = useAppDispatch();
   const { currentChatId } = useAppSelector((state) => state.message);
   const { trackUserReaction } = useTrackAnalytics();
-  const isMobile = useMobile();
+  const isMobile = useIsNarrowScreen();
   const isUserMessage = msg.sender === "user";
 
   // Convert Markdown to HTML and sanitize

--- a/Client/src/components/flowchart/flowchartSidebar/SidebarFlowchart.tsx
+++ b/Client/src/components/flowchart/flowchartSidebar/SidebarFlowchart.tsx
@@ -20,7 +20,7 @@ import MobileHeader from "@/components/layout/MobileHeader";
 
 // Hooks
 import { useUserData } from "@/hooks/useUserData";
-import useMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 
 // Env vars
 import { environment } from "@/helpers/getEnvironmentVars";
@@ -54,7 +54,7 @@ export function SidebarFlowchart() {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const { open } = useSidebar();
-  const isMobile = useMobile();
+  const isMobile = useIsNarrowScreen();
   const { flowchartList } = useAppSelector((state) => state.flowchart);
   const { selections } = useAppSelector((state) => state.flowSelection);
   const { userData, handleChangeFlowchartInformation, handleSave } =

--- a/Client/src/components/flowchart/layout/FlowchartUnitCounts.tsx
+++ b/Client/src/components/flowchart/layout/FlowchartUnitCounts.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 import { useAppSelector } from "@/redux";
 import { UnitCounts } from "@polylink/shared/types";
-import useIsMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 
 const FlowchartUnitCounts = () => {
-  const isMobile = useIsMobile();
+  const isMobile = useIsNarrowScreen();
 
   const { flowchartData } = useAppSelector((state) => state.flowchart);
   const [units, setUnits] = useState<UnitCounts>({

--- a/Client/src/components/layout/CalendarPage/CalendarPageLayout.tsx
+++ b/Client/src/components/layout/CalendarPage/CalendarPageLayout.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import CalendarPageHeader from "./CalendarPageHeader";
 import OuterSidebar from "../OuterIconSidebar";
-import useMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 import MobileHeader from "../MobileHeader";
 
 type SectionPageLayoutProps = {
@@ -9,7 +9,7 @@ type SectionPageLayoutProps = {
 };
 
 const CalendarPageLayout = ({ children }: SectionPageLayoutProps) => {
-  const isMobile = useMobile();
+  const isMobile = useIsNarrowScreen();
   return (
     <div className="flex flex-col h-full">
       <div className="flex">

--- a/Client/src/components/layout/ChatPage/ChatPageSidebar.tsx
+++ b/Client/src/components/layout/ChatPage/ChatPageSidebar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from "react";
 import { logActions, useAppDispatch, useAppSelector } from "@/redux";
 
 // Hooks
-import useMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 
 // My components
 import ChatLogList from "@/components/chatLog/ChatLogList";
@@ -21,7 +21,7 @@ import {
 import useDeviceType from "@/hooks/useDeviceType";
 
 export function ChatPageSidebar() {
-  const isMobile = useMobile();
+  const isMobile = useIsNarrowScreen();
   const deviceType = useDeviceType();
 
   const dispatch = useAppDispatch();

--- a/Client/src/components/layout/FlowchartPage/FlowchartLayout.tsx
+++ b/Client/src/components/layout/FlowchartPage/FlowchartLayout.tsx
@@ -7,14 +7,14 @@ import DragDropContextWrapper from "@/components/layout/DragDropContxtWrapper";
 import FlowchartHeader from "@/components/layout/FlowchartPage/FlowchartHeader";
 
 // Hooks
-import useMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 
 // Redux
 import { useAppSelector } from "@/redux";
 
 const FlowchartLayout = ({ children }: { children: React.ReactNode }) => {
   const { flowchartData } = useAppSelector((state) => state.flowchart);
-  const isMobile = useMobile();
+  const isMobile = useIsNarrowScreen();
   return (
     <DragDropContextWrapper>
       <SidebarFlowchart />

--- a/Client/src/components/layout/ProfilePage/ProfilePageLayout.tsx
+++ b/Client/src/components/layout/ProfilePage/ProfilePageLayout.tsx
@@ -10,13 +10,13 @@ import OuterSidebar from "@/components/layout/OuterIconSidebar";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 // Hooks
-import useIsMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 
 type ProfilePageLayoutProps = {
   children: ReactNode;
 };
 const ProfilePageLayout = ({ children }: ProfilePageLayoutProps) => {
-  const isMobile = useIsMobile();
+  const isMobile = useIsNarrowScreen();
 
   return (
     <div className="min-h-screen">

--- a/Client/src/components/layout/SectionPage/SectionPageLayout.tsx
+++ b/Client/src/components/layout/SectionPage/SectionPageLayout.tsx
@@ -5,7 +5,7 @@ import SectionPageHeader from "./SectionPageHeader";
 import MobileHeader from "@/components/layout/MobileHeader";
 
 // Hooks
-import useMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 import OuterSidebar from "../OuterIconSidebar";
 
 type SectionPageLayoutProps = {
@@ -13,7 +13,7 @@ type SectionPageLayoutProps = {
 };
 
 const SectionPageLayout = ({ children }: SectionPageLayoutProps) => {
-  const isMobile = useMobile();
+  const isMobile = useIsNarrowScreen();
 
   return (
     <div className="flex flex-col h-full">

--- a/Client/src/components/layout/splashPage/SplashHeader.tsx
+++ b/Client/src/components/layout/splashPage/SplashHeader.tsx
@@ -1,4 +1,4 @@
-import useIsMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 import { useNavigate } from "react-router-dom";
 import { RxHamburgerMenu } from "react-icons/rx";
 import { useState } from "react";
@@ -11,7 +11,7 @@ import { IoIosInformationCircleOutline } from "react-icons/io";
 
 const SplashHeader = () => {
   const navigate = useNavigate();
-  const isMobile = useIsMobile();
+  const isMobile = useIsNarrowScreen();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const handleLinkClick = (path: string) => {

--- a/Client/src/components/register/SignInFlow/index.tsx
+++ b/Client/src/components/register/SignInFlow/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { useAppDispatch, authActions } from "@/redux";
 // Hooks
-import useIsMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 import { useUserData } from "@/hooks/useUserData";
 // Components
 import { Button } from "@/components/ui/button";
@@ -23,7 +23,7 @@ const signInFlowSteps = [
 const SignInFlow = () => {
   const dispatch = useAppDispatch();
   const { handleSave, userData } = useUserData();
-  const isMobile = useIsMobile();
+  const isMobile = useIsNarrowScreen();
 
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");

--- a/Client/src/components/register/TitleCard.tsx
+++ b/Client/src/components/register/TitleCard.tsx
@@ -1,4 +1,4 @@
-import useIsMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 
 // TitleCard.tsx
 type TitleCardProps = {
@@ -7,7 +7,7 @@ type TitleCardProps = {
 };
 
 const TitleCard = ({ title, description }: TitleCardProps) => {
-  const isMobile = useIsMobile();
+  const isMobile = useIsNarrowScreen();
 
   return (
     <div className="relative w-full h-full">

--- a/Client/src/components/section/layout/SectionContainer.tsx
+++ b/Client/src/components/section/layout/SectionContainer.tsx
@@ -4,7 +4,7 @@ import { useAppSelector } from "@/redux";
 import { CourseCatalog } from "@/components/section/currentSectionList/SectionDoc";
 import InitialSectionState from "@/components/section/emptyState/InitialSectionState";
 import SectionLoading from "@/components/section/emptyState/SectionLoading";
-import useIsMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 import { PaginationFooter } from "@/components/section/layout/PaginationFooter";
 import NoSectionsFound from "@/components/section/emptyState/NoSectionsFound";
 
@@ -15,7 +15,7 @@ import { transformSectionsToCatalog } from "@/helpers/transformSection";
 import { ScrollArea } from "@/components/ui/scroll-area";
 
 const SectionContainer = () => {
-  const isMobile = useIsMobile();
+  const isMobile = useIsNarrowScreen();
   const { sections, isInitialState, loading } = useAppSelector(
     (state) => state.section
   );

--- a/Client/src/components/ui/sidebar.tsx
+++ b/Client/src/components/ui/sidebar.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
 import { VariantProps, cva } from "class-variance-authority";
 import { PanelLeft } from "lucide-react";
-import useIsMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 import { cn } from "@/lib/utils";
 import { Button } from "./button";
 import { Input } from "./input";
@@ -69,7 +69,7 @@ const SidebarProvider = React.forwardRef<
     },
     ref
   ) => {
-    const isMobile = useIsMobile();
+    const isMobile = useIsNarrowScreen();
     const deviceType = useDeviceType();
     const [openMobile, setOpenMobile] = React.useState(false);
 

--- a/Client/src/hooks/useIsNarrowScreen.ts
+++ b/Client/src/hooks/useIsNarrowScreen.ts
@@ -1,11 +1,11 @@
 import { useState, useEffect } from "react";
 
-const useIsMobile = () => {
-  const [isMobile, setIsMobile] = useState(false);
+const useIsNarrowScreen = () => {
+  const [isNarrow, setIsNarrow] = useState(false);
 
   useEffect(() => {
     const handleResize = () => {
-      setIsMobile(window.innerWidth <= 768); // Adjust breakpoint as needed
+      setIsNarrow(window.innerWidth <= 768); // Adjust breakpoint as needed
     };
 
     handleResize(); // Check on initial render
@@ -14,7 +14,7 @@ const useIsMobile = () => {
     return () => window.removeEventListener("resize", handleResize); // Cleanup
   }, []);
 
-  return isMobile;
+  return isNarrow;
 };
 
-export default useIsMobile;
+export default useIsNarrowScreen;

--- a/Client/src/pages/CalendarPage.tsx
+++ b/Client/src/pages/CalendarPage.tsx
@@ -25,10 +25,10 @@ import { Calendar } from "@polylink/shared/types";
 // UI Components
 import { TabsContent, Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 // Hooks
-import useMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 
 const CalendarPage = () => {
-  const isMobile = useMobile();
+  const isMobile = useIsNarrowScreen();
   const { calendarId } = useParams();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();

--- a/Client/src/pages/ChatPage.tsx
+++ b/Client/src/pages/ChatPage.tsx
@@ -9,7 +9,7 @@ import {
 import { useParams } from "react-router-dom";
 
 // Hooks
-import useMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 import useDeviceType from "@/hooks/useDeviceType";
 
 // My components
@@ -31,7 +31,7 @@ import { environment } from "@/helpers/getEnvironmentVars";
 
 const ChatPage = () => {
   const dispatch = useAppDispatch();
-  const isMobile = useMobile();
+  const isMobile = useIsNarrowScreen();
   const deviceType = useDeviceType();
   const { chatId } = useParams();
 

--- a/Client/src/pages/FlowchartPage.tsx
+++ b/Client/src/pages/FlowchartPage.tsx
@@ -10,11 +10,11 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import OuterSidebar from "@/components/layout/OuterIconSidebar";
 import { useParams } from "react-router-dom";
 import { environment } from "@/helpers/getEnvironmentVars";
-import useMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 
 const FlowChatPage = () => {
   const dispatch = useAppDispatch();
-  const isMobile = useMobile();
+  const isMobile = useIsNarrowScreen();
   const { flowchartId } = useParams();
   const { flowchartData, loading, currentFlowchart } = useAppSelector(
     (state) => state.flowchart

--- a/Client/src/pages/SectionPage.tsx
+++ b/Client/src/pages/SectionPage.tsx
@@ -1,4 +1,4 @@
-import useMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 
 // My Components
 import SectionPageLayout from "@/components/layout/SectionPage/SectionPageLayout";
@@ -12,7 +12,7 @@ import MobileSectionPageLayout from "@/components/layout/SectionPage/MobileSecti
 import useDeviceType from "@/hooks/useDeviceType";
 
 const SectionPage = () => {
-  const isMobile = useMobile();
+  const isMobile = useIsNarrowScreen();
   const deviceType = useDeviceType();
 
   return (

--- a/Client/src/pages/register/Register.tsx
+++ b/Client/src/pages/register/Register.tsx
@@ -1,12 +1,12 @@
 // HomePage.tsx
 import SplashLayout from "@/components/layout/splashPage/SplashLayout";
 import TitleCard from "@/components/register/TitleCard";
-import useMobile from "@/hooks/use-mobile";
+import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 import { Outlet } from "react-router-dom";
 import { motion } from "framer-motion";
 
 const Register = () => {
-  const isMobile = useMobile();
+  const isMobile = useIsNarrowScreen();
 
   return (
     <SplashLayout>


### PR DESCRIPTION
## 📌 Summary

Refactoring mobile detection hook

## 🔍 Related Issues

Closes #218 

## 🛠 Changes Made

- Refactored the `useIsMobile` hook to `useIsNarrowScreen`. Functionality still remains the same, and this just a renaming of all variables relating to the mobile hook across the entire codebase.

## ✅ Checklist

- [ ✅ ] My code follows the **PolyLink Contribution Guidelines**.
- [ ✅ ] I have **tested my changes** to ensure they work as expected.
- [ ✅ ] I have **documented my changes** (if applicable).
- [ ✅ ] My PR has **a clear title and description**.

## 📸 Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/dcae98c1-3d42-42b6-a41b-94e4a8bba05d)
![image](https://github.com/user-attachments/assets/ffbcca08-84af-488b-bd27-17946f53c30b)

## ❓ Additional Notes
N/A
