### PR TITLE
Update schedule generation button text and adjust default preferences

### DIFF
--- a/Client/src/components/calendar/buildSchedule/CalendarBuilderForm.tsx
+++ b/Client/src/components/calendar/buildSchedule/CalendarBuilderForm.tsx
@@ -101,7 +101,7 @@ const CalendarBuilderForm = ({
           <SelectedSectionContainer form={form} />
         </BuildScheduleContainer>
         <LeftSectionFooter
-          formText="New Schedule"
+          formText="Generate Schedule"
           buttonText="Save Schedule"
           onFormSubmit={handleBuildSchedule}
           onClick={handleSaveSchedule}

--- a/Client/src/components/calendar/buildSchedule/preferences/Preferences.tsx
+++ b/Client/src/components/calendar/buildSchedule/preferences/Preferences.tsx
@@ -26,7 +26,7 @@ const Preferences = ({
         form={form}
         label="Only Open Classes"
         name="openOnly"
-        defaultChecked={true}
+        defaultChecked={false}
       />
       <FormSwitch
         form={form}

--- a/Client/src/redux/calendar/calendarSlice.ts
+++ b/Client/src/redux/calendar/calendarSlice.ts
@@ -54,7 +54,7 @@ const initialState: calendarState = {
     minInstructorRating: "",
     maxInstructorRating: "",
     timeRange: "",
-    openOnly: true,
+    openOnly: false,
     useCurrentSchedule: false,
     showOverlappingClasses: false,
   },


### PR DESCRIPTION
## 📌 Summary

- minor frontend changes for schedule/calendar builder page

## 🔍 Related Issues
N/A
## 🛠 Changes Made

- Edited `CalendarBuilderForm.tsx` to have "New Schedule" button be "Generate Schedule"
- Updated default value for "Only Open Classes" button to false in `calendarSlice.ts` and `buildschedule/preferences/Preferences.tsx`

## ✅ Checklist

- [ ✅] My code follows the **PolyLink Contribution Guidelines**.
- [ ✅] I have **tested my changes** to ensure they work as expected.
- [ ✅] I have **documented my changes** (if applicable).
- [ ✅] My PR has **a clear title and description**.

## 📸 Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/41334055-40c6-4aa1-af43-29fca6c08c12)

## ❓ Additional Notes
N/A
