### PR TITLE
Filtering bugs fixed

### DIFF
--- a/Client/src/components/classSearch/courseFilters/courseInformation/CourseInformation.tsx
+++ b/Client/src/components/classSearch/courseFilters/courseInformation/CourseInformation.tsx
@@ -147,9 +147,13 @@ const CourseInformation = ({
                   label: subject.description,
                 }))}
                 handleChangeItem={(_, selectedValue) => {
-                  form.setValue("subject", selectedValue);
+                  // If "none" is selected, set the value to an empty string
+                  form.setValue(
+                    "subject",
+                    selectedValue === "none" ? "" : selectedValue
+                  );
                 }}
-                selectedItem={field.value || ""}
+                selectedItem={field.value === "none" ? "" : field.value || ""}
               />
             </FormControl>
           </FormItem>

--- a/Client/src/components/classSearch/courseFilters/helpers/api/subjects.ts
+++ b/Client/src/components/classSearch/courseFilters/helpers/api/subjects.ts
@@ -1,4 +1,5 @@
 const SUBJECTS = [
+  { subject: "none", description: "No Subject" },
   { subject: "AERO", description: "Aerospace Engineering" },
   { subject: "AGB", description: "Agribusiness" },
   { subject: "AGC", description: "Agricultural Communication" },

--- a/Client/src/components/classSearch/courseFilters/instructorAndRatings/Instructor.tsx
+++ b/Client/src/components/classSearch/courseFilters/instructorAndRatings/Instructor.tsx
@@ -55,6 +55,7 @@ const Instructor = ({
                       form.setValue("instructors", [...current, instructor]);
                     }
                   }}
+                  type="instructor"
                 />
                 <DeletableTags
                   tags={form.getValues("instructors") || []}

--- a/Client/src/components/classSearch/reusable/filter/SearchBar.tsx
+++ b/Client/src/components/classSearch/reusable/filter/SearchBar.tsx
@@ -24,12 +24,14 @@ type SearchbarProps = {
   onSelect: (value: string) => void;
   fetchData: (value: string) => Promise<any[]>;
   placeholder?: string;
+  type?: "course" | "instructor";
 };
 
 const Searchbar = ({
   onSelect,
   fetchData,
   placeholder = "Search",
+  type = "course",
 }: SearchbarProps) => {
   const [value, setValue] = useState("");
   const [inputValue, setInputValue] = useState("");
@@ -118,7 +120,11 @@ const Searchbar = ({
               return (
                 <CommandItem
                   key={index}
-                  value={`${item.courseId} - ${item.displayName}`}
+                  value={
+                    type === "course"
+                      ? `${item.courseId} - ${item.displayName}`
+                      : item.name
+                  }
                   onSelect={(currentValue) => {
                     setValue(currentValue === value ? "" : currentValue);
                     onSelect(currentValue);
@@ -128,7 +134,9 @@ const Searchbar = ({
                     setData([]);
                   }}
                 >
-                  {`${item.courseId} - ${item.displayName}`}
+                  {type === "course"
+                    ? `${item.courseId} - ${item.displayName}`
+                    : item}
                 </CommandItem>
               );
             })}


### PR DESCRIPTION
## 📌 Summary

Added a "No Subject" option to the subject dropdown to allow users to easily clear their subject selection without resetting all filters.

## 🔍 Related Issues

Closes #[issue number]

## 🛠 Changes Made

- Added a "No Subject" option to the `SUBJECTS` constant in `subjects.ts` with:
  - `subject: "none"` as the value
  - `description: "No Subject"` as the label
  - Placed at the top of the list for easy access

- Modified the subject dropdown in `CourseInformation.tsx` to:
  - Handle the special "none" value in the `handleChangeItem` function
  - Convert "none" to an empty string when setting the form value
  - Properly display the selected item based on the field value

## ✅ Checklist

- [x] My code follows the **PolyLink Contribution Guidelines**.
- [x] I have **tested my changes** to ensure they work as expected.
- [x] I have **documented my changes** (if applicable).
- [x] My PR has **a clear title and description**.

## 📸 Screenshots (if applicable)

[Add a screenshot showing the subject dropdown with the "No Subject" option]

## ❓ Additional Notes

This change improves the user experience by providing a clear way to remove the subject filter without affecting other filter settings. The "No Subject" option is placed at the top of the dropdown for easy access, and the implementation handles the special "none" value appropriately to maintain compatibility with the Radix UI Select component.
