### PR TITLE
Filter based on instruction mode

### DIFF
--- a/Client/src/components/classSearch/courseFilters/helpers/constants.ts
+++ b/Client/src/components/classSearch/courseFilters/helpers/constants.ts
@@ -35,7 +35,9 @@ export const SECTION_FILTERS_SCHEMA = z.object({
   maxCatalogNumber: z.string().optional(),
   // Allow multiple course attributes
   courseAttributes: z.array(z.enum(COURSE_ATTRIBUTES)).optional(),
-  instructionMode: z.string(z.enum(["P", "A"])).optional(),
+  instructionMode: z
+    .string(z.enum(["P", "A", "AM", "PS", "SA", "SM"]))
+    .optional(),
   instructors: z.array(z.string()).optional(),
   isTechElective: z.boolean().optional(),
   techElectives: z

--- a/Client/src/components/classSearch/courseFilters/scheduling/Scheduling.tsx
+++ b/Client/src/components/classSearch/courseFilters/scheduling/Scheduling.tsx
@@ -101,8 +101,12 @@ const Scheduling = ({
             <FormControl>
               <div className="grid grid-cols-2 gap-2">
                 {[
-                  ["In-Person", "P"],
-                  ["Online", "A"],
+                  ["In-Person", "PS"],
+                  ["Asynchronous", "SA"],
+                  ["Synchronous", "PA"],
+                  ["In-Person/Async Hybrid", "P"],
+                  ["In-Person/Sync Hybrid", "AM"],
+                  ["Sync/Async Hybrid", "SM"],
                 ].map(([mode, code]) => (
                   <Button
                     key={mode}

--- a/server/src/db/models/section/sectionServices.ts
+++ b/server/src/db/models/section/sectionServices.ts
@@ -211,15 +211,30 @@ function buildSectionsQuery(
   if (filter.instructionMode) {
     let allowedCodes: string[] = [];
 
-    if (filter.instructionMode.includes("P")) {
-      allowedCodes = allowedCodes.concat(["P", "PS", "AM"]);
+    // Map the single instruction mode code to the appropriate codes
+    switch (filter.instructionMode) {
+      case "P": // In-Person
+        allowedCodes = ["P"];
+        break;
+      case "A": // Online
+        allowedCodes = ["A"];
+        break;
+      case "AM": // In-Person/Sync Hybrid
+        allowedCodes = ["AM"];
+        break;
+      case "PS": // In-Person/Async Hybrid
+        allowedCodes = ["PS"];
+        break;
+      case "SA": // Asynchronous
+        allowedCodes = ["SA"];
+        break;
+      case "SM": // Sync/Async Hybrid
+        allowedCodes = ["SM"];
+        break;
+      default:
+        // If the code doesn't match any known code, just use it as is
+        allowedCodes = [filter.instructionMode];
     }
-    if (filter.instructionMode.includes("A")) {
-      allowedCodes = allowedCodes.concat(["PA", "SM", "SA"]);
-    }
-
-    // Ensure there are no duplicates (if that matters)
-    allowedCodes = Array.from(new Set(allowedCodes));
 
     query.instructionMode = { $in: allowedCodes };
   }


### PR DESCRIPTION
## 📌 Summary

Updated the backend section query builder to properly handle instruction mode filtering based on the single code selection in the frontend form.

## 🔍 Related Issues

Closes #

## 🛠 Changes Made

- Updated the instruction mode filtering logic in `server/src/db/models/section/sectionServices.ts` to handle single code selection from the frontend
- Modified the switch statement to correctly map each instruction mode code to its corresponding database value
- Ensured the backend filtering logic matches the frontend UI options:
  - "PS" - In-Person
  - "SA" - Asynchronous
  - "PA" - Synchronous
  - "P" - In-Person/Async Hybrid
  - "AM" - In-Person/Sync Hybrid
  - "SM" - Sync/Async Hybrid

## ✅ Checklist

- [x] My code follows the **PolyLink Contribution Guidelines**.
- [x] I have **tested my changes** to ensure they work as expected.
- [x] I have **documented my changes** (if applicable).
- [x] My PR has **a clear title and description**.

## 📸 Screenshots (if applicable)

## ❓ Additional Notes

The changes ensure that when a user selects an instruction mode option in the frontend form, the backend correctly filters sections based on that selection. This maintains the existing user experience while fixing the backend filtering logic to properly handle the instruction mode codes.
