### PR TITLE
Weekly schedule visibile sections

### DIFF
--- a/Client/src/components/scheduleBuilder/buildSchedule/selectedSections/SectionsChosen.tsx
+++ b/Client/src/components/scheduleBuilder/buildSchedule/selectedSections/SectionsChosen.tsx
@@ -3,6 +3,7 @@ import { SelectedSection } from "@polylink/shared/types";
 import { Button } from "@/components/ui/button";
 import { motion, AnimatePresence } from "framer-motion";
 import { Checkbox } from "@/components/ui/checkbox";
+import { FaEye } from "react-icons/fa";
 
 import { ChevronRight } from "lucide-react";
 import { convertTo12HourFormat } from "@/components/classSearch/helpers/timeFormatter";
@@ -20,6 +21,7 @@ import {
 import { useNavigate } from "react-router-dom";
 import LabelSection from "@/components/classSearch/reusable/sectionInfo/LabelSection";
 import BadgeSection from "@/components/classSearch/reusable/sectionInfo/BadgeSection";
+import { toggleHiddenSection } from "@/redux/schedule/scheduleSlice";
 
 const SectionsChosen = () => {
   const navigate = useNavigate();
@@ -301,7 +303,13 @@ const SectionCard: React.FC<{
   isSelected: boolean;
 }> = ({ section, isSelected }) => {
   const dispatch = useAppDispatch();
-  const { currentScheduleTerm } = useAppSelector((state) => state.schedule);
+  const { currentScheduleTerm, hiddenSections, currentSchedule } =
+    useAppSelector((state) => state.schedule);
+  const isHidden = hiddenSections.includes(section.classNumber);
+  const isInSchedule =
+    currentSchedule?.sections.some(
+      (s) => s.classNumber === section.classNumber
+    ) ?? false;
 
   const handleRemove = () => {
     dispatch(
@@ -314,6 +322,10 @@ const SectionCard: React.FC<{
 
   const handleToggleSelection = () => {
     dispatch(toggleSectionForSchedule(section.classNumber));
+  };
+
+  const handleToggleHidden = () => {
+    dispatch(toggleHiddenSection(section.classNumber));
   };
 
   // Extract and format start & end time
@@ -357,13 +369,27 @@ const SectionCard: React.FC<{
             </span>
           </div>
 
-          {/* Checkbox moved to the right */}
-          <Checkbox
-            id={`section-${section.classNumber}`}
-            checked={isSelected}
-            onCheckedChange={handleToggleSelection}
-            className="h-4 w-4 border-gray-700 dark:border-slate-900"
-          />
+          {/* Checkbox and Eye Icon */}
+          <div className="flex items-center gap-2">
+            {isInSchedule && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className={`h-6 w-6 text-gray-700 dark:text-gray-700 dark:hover:text-gray-800 dark:hover:bg-transparent ${
+                  isHidden ? "opacity-50" : ""
+                }`}
+                onClick={handleToggleHidden}
+              >
+                <FaEye className="h-3 w-3" />
+              </Button>
+            )}
+            <Checkbox
+              id={`section-${section.classNumber}`}
+              checked={isSelected}
+              onCheckedChange={handleToggleSelection}
+              className="h-4 w-4 border-gray-700 dark:border-slate-900"
+            />
+          </div>
         </div>
 
         {/* Days - Bubble Style */}

--- a/Client/src/components/scheduleBuilder/weeklySchedule/ScheduleTimeSlots.tsx
+++ b/Client/src/components/scheduleBuilder/weeklySchedule/ScheduleTimeSlots.tsx
@@ -14,15 +14,18 @@ import { convertTo12HourFormat } from "@/components/classSearch/helpers/timeForm
 import { formatProfessorNames } from "@/components/scheduleBuilder/helpers";
 import useIsNarrowScreen from "@/hooks/useIsNarrowScreen";
 import NarrowScreenScheduleSectionInfo from "./NarrowScreenScheduleSectionInfo";
+import { Button } from "@/components/ui/button";
+import { FaEye } from "react-icons/fa";
 // Add 'conflict' as a prop
 interface ScheduleTimeSlotsProps {
   event: ScheduleClassSection;
   conflict?: boolean;
   onClick: () => void;
+  onEyeClick: () => void;
 }
 
 const ScheduleTimeSlots = forwardRef<HTMLDivElement, ScheduleTimeSlotsProps>(
-  ({ event, onClick }, ref) => {
+  ({ event, onClick, onEyeClick }, ref) => {
     const isNarrowScreen = useIsNarrowScreen();
     const modalRef = useRef<HTMLDivElement>(null);
     const startTime = event.extendedProps.start_time
@@ -39,6 +42,7 @@ const ScheduleTimeSlots = forwardRef<HTMLDivElement, ScheduleTimeSlotsProps>(
      * You can also do this on the <div> or the <CustomModalTriggerButton>,
      * depending on the exact design you want.
      */
+
     return (
       <div ref={ref} className="flex items-center justify-start w-full h-full">
         <Modal>
@@ -47,7 +51,7 @@ const ScheduleTimeSlots = forwardRef<HTMLDivElement, ScheduleTimeSlotsProps>(
             className="rounded-md hover:opacity-90 transition-opacity cursor-pointer min-h-full w-full"
             onClick={onClick}
           >
-            <div className="flex flex-col items-start justify-center p-1 sm:p-2 w-full">
+            <div className="flex flex-col items-start justify-center p-1 sm:p-2 w-full relative">
               <div className="text-[10px] sm:text-xs text-gray-700 dark:text-gray-700 whitespace-nowrap">
                 {startTime} - {endTime}
               </div>
@@ -59,6 +63,16 @@ const ScheduleTimeSlots = forwardRef<HTMLDivElement, ScheduleTimeSlotsProps>(
               </div>
             </div>
           </CustomModalTriggerButton>
+          <Button
+            variant="ghost"
+            size="icon"
+            className={`absolute h-6 w-6 text-gray-700 dark:text-gray-700 dark:hover:text-gray-800 dark:hover:bg-transparent ${
+              isNarrowScreen ? "bottom-0 right-0" : "top-0 right-0"
+            }`}
+            onClick={onEyeClick}
+          >
+            <FaEye className="h-3 w-3" />
+          </Button>
           {isNarrowScreen ? (
             <NarrowScreenModal ref={modalRef}>
               <NarrowScreenScheduleSectionInfo />

--- a/Client/src/components/scheduleBuilder/weeklySchedule/WeeklySchedule.tsx
+++ b/Client/src/components/scheduleBuilder/weeklySchedule/WeeklySchedule.tsx
@@ -58,7 +58,7 @@ const WeeklySchedule: React.FC<WeeklyScheduleProps> = ({
   const [calendarHeight, setCalendarHeight] = useState(height);
   const [containerHeight, setContainerHeight] = useState(0);
   const [asyncCoursesHeight, setAsyncCoursesHeight] = useState(0);
-
+  const [invisibleEvents, setInvisibleEvents] = useState<number[]>([]);
   // Update window height on resize
   useEffect(() => {
     const handleResize = () => {
@@ -308,8 +308,11 @@ const WeeklySchedule: React.FC<WeeklyScheduleProps> = ({
     }
   }
 
-  // 3) Combine
-  const finalEvents = [...backgroundEvents, ...events];
+  // 3) Combine background events and normal events
+  // Instead of using state for finalEvents, compute it directly
+  const filteredEvents = [...backgroundEvents, ...events].filter(
+    (e) => !invisibleEvents.includes(e.classNumber)
+  );
 
   const handleEventClick = (eventClickArg: any) => {
     const { classNumber } = eventClickArg.event.extendedProps;
@@ -320,6 +323,12 @@ const WeeklySchedule: React.FC<WeeklyScheduleProps> = ({
       })
     );
   };
+
+  const handleEyeClick = (event: any) => {
+    const classNumber = event.event.extendedProps.classNumber;
+    setInvisibleEvents((prev) => [...prev, classNumber]);
+  };
+
   // Handle AsyncCourses height changes
   const handleAsyncCoursesHeightChange = (height: number) => {
     setAsyncCoursesHeight(height);
@@ -375,7 +384,7 @@ const WeeklySchedule: React.FC<WeeklyScheduleProps> = ({
             slotMaxTime="21:00:00"
             slotDuration="01:00:00"
             hiddenDays={[0, 6]}
-            events={finalEvents}
+            events={filteredEvents}
             contentHeight={isProfilePage ? "80vh" : calendarHeight}
             expandRows={true}
             titleFormat={{}} // (Empty: no title text on top)
@@ -408,6 +417,7 @@ const WeeklySchedule: React.FC<WeeklyScheduleProps> = ({
                 <ScheduleTimeSlots
                   event={arg.event as unknown as ScheduleClassSection}
                   onClick={() => handleEventClick(arg)}
+                  onEyeClick={() => handleEyeClick(arg)}
                 />
               );
             }}

--- a/Client/src/components/scheduleBuilder/weeklySchedule/WeeklySchedule.tsx
+++ b/Client/src/components/scheduleBuilder/weeklySchedule/WeeklySchedule.tsx
@@ -5,6 +5,7 @@ import timeGridPlugin from "@fullcalendar/timegrid";
 import dayGridPlugin from "@fullcalendar/daygrid";
 import interactionPlugin from "@fullcalendar/interaction";
 import { useAppDispatch, useAppSelector, classSearchActions } from "@/redux";
+import { toggleHiddenSection } from "@/redux/schedule/scheduleSlice";
 
 // My components
 import { ScheduleTimeSlots } from "@/components/scheduleBuilder";
@@ -52,13 +53,14 @@ const WeeklySchedule: React.FC<WeeklyScheduleProps> = ({
   isProfilePage = false,
 }) => {
   const dispatch = useAppDispatch();
-  const { currentScheduleTerm } = useAppSelector((state) => state.schedule);
+  const { currentScheduleTerm, hiddenSections } = useAppSelector(
+    (state) => state.schedule
+  );
   const containerRef = useRef<HTMLDivElement>(null);
   const [windowHeight, setWindowHeight] = useState(window.innerHeight);
   const [calendarHeight, setCalendarHeight] = useState(height);
   const [containerHeight, setContainerHeight] = useState(0);
   const [asyncCoursesHeight, setAsyncCoursesHeight] = useState(0);
-  const [invisibleEvents, setInvisibleEvents] = useState<number[]>([]);
   // Update window height on resize
   useEffect(() => {
     const handleResize = () => {
@@ -311,7 +313,7 @@ const WeeklySchedule: React.FC<WeeklyScheduleProps> = ({
   // 3) Combine background events and normal events
   // Instead of using state for finalEvents, compute it directly
   const filteredEvents = [...backgroundEvents, ...events].filter(
-    (e) => !invisibleEvents.includes(e.classNumber)
+    (e) => !hiddenSections.includes(e.classNumber)
   );
 
   const handleEventClick = (eventClickArg: any) => {
@@ -326,7 +328,7 @@ const WeeklySchedule: React.FC<WeeklyScheduleProps> = ({
 
   const handleEyeClick = (event: any) => {
     const classNumber = event.event.extendedProps.classNumber;
-    setInvisibleEvents((prev) => [...prev, classNumber]);
+    dispatch(toggleHiddenSection(classNumber));
   };
 
   // Handle AsyncCourses height changes

--- a/Client/src/redux/schedule/scheduleSlice.ts
+++ b/Client/src/redux/schedule/scheduleSlice.ts
@@ -36,6 +36,7 @@ export interface ScheduleState {
   fetchSchedulesLoading: boolean;
   preferences: Preferences;
   currentScheduleTerm: CourseTerm;
+  hiddenSections: number[];
 }
 
 const initialState: ScheduleState = {
@@ -58,6 +59,7 @@ const initialState: ScheduleState = {
     useCurrentSchedule: false,
     showOverlappingClasses: false,
   },
+  hiddenSections: [],
 };
 
 // Fetch schedules for a specific term
@@ -216,6 +218,15 @@ const scheduleSlice = createSlice({
       state.schedules = [];
       state.currentSchedule = null;
     },
+    toggleHiddenSection(state, action: PayloadAction<number>) {
+      const classNumber = action.payload;
+      const index = state.hiddenSections.indexOf(classNumber);
+      if (index === -1) {
+        state.hiddenSections.push(classNumber);
+      } else {
+        state.hiddenSections.splice(index, 1);
+      }
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -258,6 +269,7 @@ export const {
   setCurrentSchedule,
   setPreferences,
   setCurrentScheduleTerm,
+  toggleHiddenSection,
 } = scheduleSlice.actions;
 
 export const scheduleReducer = scheduleSlice.reducer;

--- a/Client/src/redux/schedule/scheduleSlice.ts
+++ b/Client/src/redux/schedule/scheduleSlice.ts
@@ -220,6 +220,7 @@ const scheduleSlice = createSlice({
     },
     toggleHiddenSection(state, action: PayloadAction<number>) {
       const classNumber = action.payload;
+      // Toggle the visibility of a section by adding it to or removing it from the hiddenSections array.
       const index = state.hiddenSections.indexOf(classNumber);
       if (index === -1) {
         state.hiddenSections.push(classNumber);


### PR DESCRIPTION
## 📌 Summary

This PR adds the ability for users to hide sections from their schedule view, providing more control over their schedule visualization. Users can toggle section visibility using an eye icon in both the schedule view and the sections list.

## 🔍 Related Issues

Closes #

## 🛠 Changes Made

- Added `hiddenSections` state to the Redux store to track which sections are hidden
- Implemented `toggleHiddenSection` reducer to handle showing/hiding sections
- Added eye icon to `ScheduleTimeSlots` component for toggling section visibility in the calendar view
- Added eye icon to `SectionsChosen` component for toggling section visibility in the sections list
- Eye icon only appears for sections that are part of the current generated schedule
- Hidden sections are visually indicated with reduced opacity
- Hidden sections are filtered out from the calendar view

## ✅ Checklist

- [x] My code follows the **PolyLink Contribution Guidelines**.
- [x] I have **tested my changes** to ensure they work as expected.
- [x] I have **documented my changes** (if applicable).
- [x] My PR has **a clear title and description**.

## 📸 Screenshots (if applicable)

<!-- Add screenshots or GIFs to help reviewers understand the changes -->

## ❓ Additional Notes

- The visibility state is persisted in Redux, so it's shared between both the calendar view and sections list
- Users can toggle visibility by clicking the eye icon in either location
- This feature helps users focus on specific sections of their schedule by temporarily hiding others
- The eye icon is only shown for sections that are actually part of the current generated schedule
