### PR TITLE
Saving calendar based on visible sections

### DIFF
--- a/Client/src/components/scheduleBuilder/buildSchedule/ScheduleBuilderForm.tsx
+++ b/Client/src/components/scheduleBuilder/buildSchedule/ScheduleBuilderForm.tsx
@@ -29,9 +29,8 @@ const ScheduleBuilderForm = ({
   const { selectedSections, sectionsForSchedule } = useAppSelector(
     (state) => state.sectionSelection
   );
-  const { currentSchedule, currentScheduleTerm } = useAppSelector(
-    (state) => state.schedule
-  );
+  const { currentSchedule, currentScheduleTerm, hiddenSections } =
+    useAppSelector((state) => state.schedule);
   const schedulePreferences = useAppSelector(
     (state) => state.schedule.preferences
   );
@@ -111,11 +110,14 @@ const ScheduleBuilderForm = ({
         currentScheduleTerm
       );
 
+      // Filter out hidden sections when saving
+      const visibleSections = scheduleToSave.sections.filter(
+        (section) => !hiddenSections.includes(section.classNumber)
+      );
+
       dispatch(
         scheduleActions.createOrUpdateScheduleAsync({
-          classNumbers: scheduleToSave.sections.map(
-            (section) => section.classNumber
-          ),
+          classNumbers: visibleSections.map((section) => section.classNumber),
           term: currentScheduleTerm,
         })
       );


### PR DESCRIPTION
## 📌 Summary

This PR modifies the schedule saving functionality to exclude hidden sections when saving a schedule, ensuring that only visible sections are persisted.

## 🔍 Related Issues

Closes #

## 🛠 Changes Made

- Modified `handleSaveSchedule` function to filter out hidden sections before saving
- Added `hiddenSections` to the state selector in `ScheduleBuilderForm`
- Only visible sections (not in the `hiddenSections` array) are now included in the saved schedule

## ✅ Checklist

- [x] My code follows the **PolyLink Contribution Guidelines**.
- [x] I have **tested my changes** to ensure they work as expected.
- [x] I have **documented my changes** (if applicable).
- [x] My PR has **a clear title and description**.

## 📸 Screenshots (if applicable)

<!-- Add screenshots or GIFs to help reviewers understand the changes -->

## ❓ Additional Notes

- This change ensures that the saved schedule matches what the user is actually seeing in their current view
- Hidden sections are completely excluded from the saved schedule, not just hidden in the view
- This better reflects user intent since they've explicitly chosen to hide certain sections
- The change maintains consistency between what users see and what gets saved
