### PR TITLE
Fall2025 sections insertted

### DIFF
--- a/Client/src/components/classSearch/TermSelector.tsx
+++ b/Client/src/components/classSearch/TermSelector.tsx
@@ -19,10 +19,11 @@ const TermSelector = ({ form }: TermSelectorProps) => {
         <FormItem>
           <TitleLabel title="Term" />
           <FormControl>
-            <div className="grid grid-cols-2 gap-2">
+            <div className="grid grid-cols-3 gap-2">
               {[
                 ["Spring 2025", "spring2025"],
                 ["Summer 2025", "summer2025"],
+                ["Fall 2025", "fall2025"],
               ].map(([label, value]) => (
                 <Button
                   key={value}

--- a/Client/src/components/classSearch/courseFilters/SectionForm.tsx
+++ b/Client/src/components/classSearch/courseFilters/SectionForm.tsx
@@ -17,7 +17,7 @@ import {
 import { Form } from "@/components/ui/form";
 
 // Types
-import { SectionsFilterParams } from "@polylink/shared/types";
+import { CourseTerm, SectionsFilterParams } from "@polylink/shared/types";
 
 // Constants
 import {
@@ -28,6 +28,7 @@ import {
 import { SECTION_FILTERS_SCHEMA } from "@/components/classSearch/courseFilters/helpers/constants";
 import useDeviceType from "@/hooks/useDeviceType";
 import MobileBuildScheduleContainer from "@/components/scheduleBuilder/buildSchedule/layout/MobileBuildScheduleContainer";
+
 export type SectionFiltersForm = z.infer<typeof SECTION_FILTERS_SCHEMA>;
 
 const SectionForm = ({
@@ -47,6 +48,7 @@ const SectionForm = ({
   const form = useForm<SectionFiltersForm>({
     resolver: zodResolver(SECTION_FILTERS_SCHEMA),
     defaultValues: {
+      term: (reduxFilters.term || "fall2025") as CourseTerm,
       courseIds: reduxFilters.courseIds || [],
       status: reduxFilters.status || "",
       subject: reduxFilters.subject || "",
@@ -94,7 +96,7 @@ const SectionForm = ({
 
     // Create a filters object matching API's expected shape.
     const updatedFilters: SectionsFilterParams = {
-      term: watchedValues.term || "summer2025",
+      term: watchedValues.term || ("fall2025" as CourseTerm),
       courseIds: watchedValues.courseIds || [],
       status: watchedValues.status || "",
       subject: watchedValues.subject || "",

--- a/Client/src/components/classSearch/courseFilters/helpers/constants.ts
+++ b/Client/src/components/classSearch/courseFilters/helpers/constants.ts
@@ -14,10 +14,11 @@ export const COURSE_ATTRIBUTES = [
   "USCP",
 ] as const;
 
+const COURSE_TERMS = ["spring2025", "summer2025", "fall2025"] as const;
 export const HOURS = Array.from({ length: 14 }, (_, i) => i + 7);
 
 export const SECTION_FILTERS_SCHEMA = z.object({
-  term: z.enum(["spring2025", "summer2025"]).optional(),
+  term: z.enum(COURSE_TERMS).optional(),
   courseIds: z.array(z.string()).optional(),
   status: z.string().optional(),
   subject: z.string().optional(),
@@ -67,7 +68,7 @@ export const getInitialFilterValues = (
   concentration = ""
 ): SectionsFilterParams => {
   return {
-    term: "summer2025",
+    term: "fall2025",
     courseIds: [],
     status: "",
     subject: "",

--- a/Client/src/components/scheduleBuilder/weeklySchedule/ScheduleAverageRating.tsx
+++ b/Client/src/components/scheduleBuilder/weeklySchedule/ScheduleAverageRating.tsx
@@ -35,6 +35,8 @@ const ScheduleAverageRating: React.FC = () => {
   const formatTermDisplay = (term: string) => {
     if (term === "spring2025") {
       return "Spring 2025";
+    } else if (term === "fall2025") {
+      return "Fall 2025";
     } else if (term === "summer2025") {
       return "Summer 2025";
     }

--- a/Client/src/pages/ScheduleBuilder.tsx
+++ b/Client/src/pages/ScheduleBuilder.tsx
@@ -21,7 +21,7 @@ import {
 } from "@/components/scheduleBuilder";
 import { onNewChat } from "@/components/chat";
 // Types
-import { Schedule } from "@polylink/shared/types";
+import { CourseTerm, Schedule } from "@polylink/shared/types";
 // UI Components
 import { TabsContent, Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 // Hooks
@@ -46,9 +46,9 @@ const ScheduleBuilderPage = () => {
   );
   const userId = useAppSelector((state) => state.auth.userId);
 
-  const [tabValue, setTabValue] = useState<
-    "spring2025" | "summer2025" | "AI Chat"
-  >(currentScheduleTerm);
+  const [tabValue, setTabValue] = useState<CourseTerm | "schedule" | "AI Chat">(
+    currentScheduleTerm
+  );
   // Ref variables to prevent fetching data multiple times
   const hasFetchedassistantList = useRef(false);
 
@@ -144,11 +144,7 @@ const ScheduleBuilderPage = () => {
   }, [currentScheduleId, scheduleId, navigate]);
 
   const handleTermChange = (value: string) => {
-    dispatch(
-      scheduleActions.setCurrentScheduleTerm(
-        value as "spring2025" | "summer2025"
-      )
-    );
+    dispatch(scheduleActions.setCurrentScheduleTerm(value as CourseTerm));
     dispatch(scheduleActions.setCurrentScheduleId(undefined));
     navigate("/schedule-builder");
   };
@@ -163,11 +159,11 @@ const ScheduleBuilderPage = () => {
             <Tabs
               value={tabValue}
               onValueChange={(value) =>
-                setTabValue(value as "spring2025" | "summer2025" | "AI Chat")
+                setTabValue(value as CourseTerm | "schedule" | "AI Chat")
               }
               defaultValue={tabValue}
             >
-              <TabsList className="grid w-full grid-cols-3 dark:bg-gray-900">
+              <TabsList className="grid w-full grid-cols-4 dark:bg-gray-900">
                 <TabsTrigger
                   value="spring2025"
                   onClick={() => handleTermChange("spring2025")}
@@ -175,7 +171,7 @@ const ScheduleBuilderPage = () => {
                     currentScheduleTerm === "spring2025" ? "bg-primary" : ""
                   }
                 >
-                  Spring 2025
+                  SP25
                 </TabsTrigger>
                 <TabsTrigger
                   value="summer2025"
@@ -184,7 +180,16 @@ const ScheduleBuilderPage = () => {
                     currentScheduleTerm === "summer2025" ? "bg-primary" : ""
                   }
                 >
-                  Summer 2025
+                  SU25
+                </TabsTrigger>
+                <TabsTrigger
+                  value="fall2025"
+                  onClick={() => handleTermChange("fall2025")}
+                  className={
+                    currentScheduleTerm === "fall2025" ? "bg-primary" : ""
+                  }
+                >
+                  FA25
                 </TabsTrigger>
                 <TabsTrigger
                   value="AI Chat"
@@ -197,6 +202,9 @@ const ScheduleBuilderPage = () => {
                 <ScheduleBuilderForm onSwitchTab={() => {}} />
               </TabsContent>
               <TabsContent value="summer2025">
+                <ScheduleBuilderForm onSwitchTab={() => {}} />
+              </TabsContent>
+              <TabsContent value="fall2025">
                 <ScheduleBuilderForm onSwitchTab={() => {}} />
               </TabsContent>
               <TabsContent value="AI Chat">
@@ -233,17 +241,13 @@ const ScheduleBuilderMobile = () => {
   const { selectedSections } = useAppSelector(
     (state) => state.sectionSelection
   );
-  const [tabValue, setTabValue] = useState<
-    "spring2025" | "summer2025" | "schedule" | "AI Chat"
-  >(currentScheduleTerm);
+  const [tabValue, setTabValue] = useState<CourseTerm | "schedule" | "AI Chat">(
+    currentScheduleTerm
+  );
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
   const handleTermChange = (value: string) => {
-    dispatch(
-      scheduleActions.setCurrentScheduleTerm(
-        value as "spring2025" | "summer2025"
-      )
-    );
+    dispatch(scheduleActions.setCurrentScheduleTerm(value as CourseTerm));
     dispatch(scheduleActions.setCurrentScheduleId(undefined));
     navigate("/schedule-builder");
   };
@@ -252,26 +256,31 @@ const ScheduleBuilderMobile = () => {
     <Tabs
       value={tabValue}
       onValueChange={(value) =>
-        setTabValue(
-          value as "spring2025" | "summer2025" | "schedule" | "AI Chat"
-        )
+        setTabValue(value as CourseTerm | "schedule" | "AI Chat")
       }
       defaultValue={currentScheduleTerm}
     >
-      <TabsList className="grid w-full grid-cols-4 dark:bg-gray-900">
+      <TabsList className="grid w-full grid-cols-5 dark:bg-gray-900">
         <TabsTrigger
           value="spring2025"
           onClick={() => handleTermChange("spring2025")}
           className={currentScheduleTerm === "spring2025" ? "bg-primary" : ""}
         >
-          Spring 2025
+          SP25
         </TabsTrigger>
         <TabsTrigger
           value="summer2025"
           onClick={() => handleTermChange("summer2025")}
           className={currentScheduleTerm === "summer2025" ? "bg-primary" : ""}
         >
-          Summer 2025
+          SU25
+        </TabsTrigger>
+        <TabsTrigger
+          value="fall2025"
+          onClick={() => handleTermChange("fall2025")}
+          className={currentScheduleTerm === "fall2025" ? "bg-primary" : ""}
+        >
+          FA25
         </TabsTrigger>
         <TabsTrigger value="schedule">Schedule</TabsTrigger>
         <TabsTrigger
@@ -285,6 +294,9 @@ const ScheduleBuilderMobile = () => {
         <ScheduleBuilderForm onSwitchTab={() => setTabValue("schedule")} />
       </TabsContent>
       <TabsContent value="summer2025">
+        <ScheduleBuilderForm onSwitchTab={() => setTabValue("schedule")} />
+      </TabsContent>
+      <TabsContent value="fall2025">
         <ScheduleBuilderForm onSwitchTab={() => setTabValue("schedule")} />
       </TabsContent>
       <TabsContent value="schedule">

--- a/server/src/db/models/section/fallSectionCollection.ts
+++ b/server/src/db/models/section/fallSectionCollection.ts
@@ -1,0 +1,58 @@
+import { Section, SectionDocument } from "@polylink/shared/types";
+import { getDb } from "../../connection";
+import { Collection, Filter } from "mongodb";
+
+let sectionCollection: Collection<SectionDocument>;
+
+const initializeCollection = (): Collection<SectionDocument> => {
+  return getDb().collection("fall2025");
+};
+
+export const findSectionsByFilter = async (
+  query: Filter<SectionDocument>,
+  skip: number,
+  limit: number,
+  projection?: Record<string, number>
+): Promise<{ sections: Section[]; total: number }> => {
+  if (!sectionCollection) {
+    sectionCollection = initializeCollection();
+  }
+
+  // Get total number of matching documents for pagination
+  const total = await sectionCollection.countDocuments(query);
+
+  // Then get the specific page with .skip() and .limit()
+  const sections = (await sectionCollection
+    .find(query)
+    .project(projection || { _id: 0 })
+    .skip(skip)
+    .limit(limit)
+    .toArray()) as unknown as Promise<Section[]>;
+
+  return { sections: sections as unknown as Section[], total };
+};
+
+export const findSectionsbyProjection = async (
+  query: Filter<SectionDocument>,
+  projection: {
+    courseId?: 1;
+    courseName?: 1;
+    description?: 1;
+    units?: 1;
+    enrollmentStatus?: 1;
+    courseAttributes?: 1;
+    meetings?: 1;
+    instructors?: 1;
+    instructorWithRatings?: 1;
+  }
+): Promise<Partial<Section>[]> => {
+  if (!sectionCollection) {
+    sectionCollection = initializeCollection();
+  }
+  // Add courseId to projection always:
+  const sections = await sectionCollection
+    .find(query)
+    .project(projection)
+    .toArray();
+  return sections as unknown as Partial<Section>[];
+};

--- a/server/src/db/models/section/sectionServices.ts
+++ b/server/src/db/models/section/sectionServices.ts
@@ -14,6 +14,7 @@ import { buildNonConflictingQuery } from "../../../helpers/queryBuilders/schedul
 import { fetchPrimarySchedule } from "../schedule/scheduleServices";
 import * as summerSectionCollection from "./summerSectionCollection";
 import { transformScheduleToScheduleResponse } from "../schedule/transformSection";
+import * as fallSectionCollection from "./fallSectionCollection";
 /**
  * Build a filter object that can be passed to the collection query.
  */
@@ -343,10 +344,17 @@ export async function getSectionsByFilter(
         skip,
         limit
       );
-    } else {
+    } else if (filter.term === "spring2025") {
       // Perform the find operation with skip & limit
       // and also get a total count so you can return that in the response
       return await sectionCollection.findSectionsByFilter(query, skip, limit);
+    } else {
+      // fall2025
+      return await fallSectionCollection.findSectionsByFilter(
+        query,
+        skip,
+        limit
+      );
     }
   } catch (error) {
     if (environment === "dev") {
@@ -405,13 +413,22 @@ export async function getSectionsByIds(
         classNumbers.length // Set limit to match the number of class numbers
       );
       return result.sections;
-    } else {
+    } else if (term === "spring2025") {
       const result = await sectionCollection.findSectionsByFilter(
         query,
         0,
         classNumbers.length
       );
       return result.sections;
+    } else if (term === "fall2025") {
+      const result = await fallSectionCollection.findSectionsByFilter(
+        query,
+        0,
+        classNumbers.length
+      );
+      return result.sections;
+    } else {
+      return null;
     }
   } catch (error) {
     if (environment === "dev") {

--- a/server/src/db/models/selectedSection/selectedSectionCollection.ts
+++ b/server/src/db/models/selectedSection/selectedSectionCollection.ts
@@ -87,6 +87,7 @@ export const createOrUpdateSelectedSection = async (
               selectedSections: {
                 spring2025: {},
                 summer2025: {},
+                fall2025: {},
               },
             },
           }

--- a/server/src/routes/classSearch.ts
+++ b/server/src/routes/classSearch.ts
@@ -1,7 +1,11 @@
 import express from "express";
 import { getSectionsByFilter } from "../db/models/section/sectionServices"; // new function
 import { CustomRequest as Request } from "../types/express";
-import { SectionDocument, SectionsFilterParams } from "@polylink/shared/types";
+import {
+  CourseTerm,
+  SectionDocument,
+  SectionsFilterParams,
+} from "@polylink/shared/types";
 import { environment } from "../index";
 import { findSectionsByFilter } from "../db/models/section/sectionCollection";
 import { Filter } from "mongodb";
@@ -98,7 +102,7 @@ router.get("/", async (req: Request, res: any) => {
       isTechElective: isTechElective === "true", // Converts the string "true" to boolean true, any other value becomes false
       withNoConflicts: withNoConflicts === "true", // convert str to boolean
       isCreditNoCredit: isCreditNoCredit === "true", // convert str to boolean
-      term: term as "spring2025" | "summer2025",
+      term: term as CourseTerm,
     };
 
     // Call the service with the parsed query object

--- a/server/src/routes/llm.ts
+++ b/server/src/routes/llm.ts
@@ -14,6 +14,7 @@ import { createBio } from "../helpers/assistants/createBio/createBio";
 import { sectionQueryAssistant } from "../helpers/assistants/SectionQuery/sectionQueryAssistant";
 import { findSectionsByFilter } from "../db/models/section/sectionCollection";
 import * as summerCollection from "../db/models/section/summerSectionCollection";
+import * as fallSectionCollection from "../db/models/section/fallSectionCollection";
 import { Filter } from "mongodb";
 import { createLog, getLogById } from "../db/models/chatlog/chatLogServices";
 import { isUnauthorized } from "../helpers/auth/verifyAuth";
@@ -229,8 +230,17 @@ router.post(
         );
         sections = result.sections;
         total = result.total;
+      } else if (term === "fall2025") {
+        const result = await fallSectionCollection.findSectionsByFilter(
+          response?.query as Filter<SectionDocument>,
+          0,
+          25
+        );
+        sections = result.sections;
+        total = result.total;
+      } else {
+        throw new Error("Invalid term");
       }
-
       // Single successful response
       res.json({
         ...response,

--- a/server/src/routes/schedule.ts
+++ b/server/src/routes/schedule.ts
@@ -13,7 +13,7 @@ import { CourseTerm, CustomScheduleEvent } from "@polylink/shared/types";
 
 const router = express.Router();
 
-const VALID_TERMS = ["spring2025", "summer2025"] as const;
+const VALID_TERMS = ["spring2025", "summer2025", "fall2025"] as const;
 
 router.get("/", async (req: CustomRequest, res: any) => {
   try {

--- a/server/src/types/express/index.d.ts
+++ b/server/src/types/express/index.d.ts
@@ -1,6 +1,6 @@
 // src/types/express.d.ts
 import { DecodedIdToken } from "firebase-admin/auth";
-import { UserType } from "@polylink/shared/types";
+import { UserType, CourseTerm } from "@polylink/shared/types";
 
 declare module "express-serve-static-core" {
   interface Request {
@@ -31,7 +31,7 @@ interface CustomRequest extends Request {
     isTechElective?: string;
     withNoConflicts?: string;
     isCreditNoCredit?: string;
-    term: "spring2025" | "summer2025";
+    term: CourseTerm;
     page?: string;
   };
 }

--- a/shared/src/types/section/index.ts
+++ b/shared/src/types/section/index.ts
@@ -1,5 +1,7 @@
+import { CourseTerm } from "../selectedSection";
+
 export type Section = {
-  term: "spring2025" | "summer2025";
+  term: CourseTerm;
   classNumber: number; // unique section number (e.g. 1001)
   courseId: string; // unique course identifier (e.g. "CSC357")
   subject: string; // subject abbreviation (e.g. "CSC")
@@ -89,7 +91,7 @@ export type SectionsFilterParams = {
   };
   withNoConflicts?: boolean; // whether to filter sections with no conflicts with their current primary schedule
   isCreditNoCredit?: boolean;
-  term: "spring2025" | "summer2025";
+  term: CourseTerm;
 };
 
 // ------------------------------------------------------------
@@ -125,7 +127,7 @@ export type SectionGroup = {
 
 // Updated SectionDetail to support standalone display
 export type SectionDetail = {
-  term: "spring2025" | "summer2025";
+  term: CourseTerm;
   courseId: string;
   courseName: string;
   classNumber: number;

--- a/shared/src/types/selectedSection/index.ts
+++ b/shared/src/types/selectedSection/index.ts
@@ -22,7 +22,7 @@ export type SelectedSection = {
   isLocked?: boolean;
 };
 
-export type CourseTerm = "spring2025" | "summer2025";
+export type CourseTerm = "spring2025" | "summer2025" | "fall2025";
 
 export type SelectedSectionItem = {
   sectionId: number;


### PR DESCRIPTION
## 📌 Summary

Added support for Fall 2025 term sections to the schedule builder, including UI components, API endpoints, and data handling. This update allows users to view and manage their Fall 2025 course schedules alongside existing Spring 2025 and Summer 2025 terms.

## 🔍 Related Issues

Closes # (Please add the relevant issue number)

## 🛠 Changes Made

- Added "fall2025" to the `VALID_TERMS` constant in `server/src/routes/schedule.ts`
- Updated the schedule builder UI to include Fall 2025 tab in both desktop and mobile views
- Added Fall 2025 term handling in the section filters form
- Implemented Fall 2025 term support in the class search API endpoints
- Added Fall 2025 term validation in the schedule creation and update endpoints
- Updated the schedule builder page layout to handle Fall 2025 term selection
- Added Fall 2025 term support in the section filters and query parameters

## ✅ Checklist

- [x] My code follows the **PolyLink Contribution Guidelines**.
- [x] I have **tested my changes** to ensure they work as expected.
- [x] I have **documented my changes** (if applicable).
- [x] My PR has **a clear title and description**.

## 📸 Screenshots (if applicable)

<!-- Please add screenshots showing the new Fall 2025 tab in the schedule builder interface -->

## ❓ Additional Notes

- The changes maintain consistency with existing Spring 2025 and Summer 2025 term implementations
- The update includes both frontend and backend changes to ensure complete Fall 2025 term support
- The implementation follows the same pattern as existing terms to maintain code consistency
- The changes have been made to support the same features available for other terms (scheduling, filtering, etc.)
