### PR TITLE
Schedule builder form 

### DIFF
--- a/Client/src/components/scheduleBuilder/buildSchedule/selectedSections/SectionsChosen.tsx
+++ b/Client/src/components/scheduleBuilder/buildSchedule/selectedSections/SectionsChosen.tsx
@@ -698,6 +698,7 @@ const SectionCard: React.FC<{
   isSelected: boolean;
 }> = ({ section, isSelected }) => {
   const dispatch = useAppDispatch();
+  const { toast } = useToast();
   const { currentScheduleTerm, hiddenSections, currentSchedule } =
     useAppSelector((state) => state.schedule);
   const selectedSectionInList = useAppSelector(
@@ -758,6 +759,31 @@ const SectionCard: React.FC<{
 
   const handleAddToCalendar = async () => {
     try {
+      // Check if section term matches current schedule term
+      if (section.term !== currentScheduleTerm) {
+        toast({
+          title: `${section.courseId} (${section.classNumber}) is from ${termMap[section.term as CourseTerm]}.`,
+          description: `Please switch to ${termMap[section.term as CourseTerm]} to add this section.`,
+          variant: "destructive",
+          action: (
+            <ToastAction
+              altText="Switch Term"
+              className="dark:bg-red dark:border-white border-2"
+              onClick={() => {
+                dispatch(
+                  scheduleActions.setCurrentScheduleTerm(
+                    section.term as CourseTerm
+                  )
+                );
+              }}
+            >
+              Switch Term
+            </ToastAction>
+          ),
+        });
+        return;
+      }
+
       // First ensure the section is in selectedSections
       const isSectionNotSelected = !selectedSectionInList.some(
         (s: SelectedSection) => s.classNumber === section.classNumber

--- a/Client/src/components/scheduleBuilder/buildSchedule/selectedSections/SelectedSectionContainer.tsx
+++ b/Client/src/components/scheduleBuilder/buildSchedule/selectedSections/SelectedSectionContainer.tsx
@@ -30,12 +30,15 @@ const SelectedSectionContainer = ({
   return (
     <div className="flex flex-col h-full">
       <div className="flex flex-col gap-4">
-        <CollapsibleContentWrapper title="Classes" icon={FaBook}>
+        <CollapsibleContentWrapper title="Selected Sections" icon={FaBook}>
           {fetchSelectedSectionsLoading ? (
             <LoadingContainer />
           ) : (
             <SectionsChosen selectedSections={selectedSections} />
           )}
+        </CollapsibleContentWrapper>
+        <CollapsibleContentWrapper title="Preferences" icon={FaCalendar}>
+          <Preferences form={form} />
         </CollapsibleContentWrapper>
         <CollapsibleContentWrapper title="Schedules" icon={FaCalendar}>
           {fetchSchedulesLoading ? (
@@ -43,9 +46,6 @@ const SelectedSectionContainer = ({
           ) : (
             <SavedSchedules onSwitchTab={onSwitchTab} />
           )}
-        </CollapsibleContentWrapper>
-        <CollapsibleContentWrapper title="Preferences" icon={FaCalendar}>
-          <Preferences form={form} />
         </CollapsibleContentWrapper>
       </div>
     </div>

--- a/Client/src/redux/schedule/scheduleSlice.ts
+++ b/Client/src/redux/schedule/scheduleSlice.ts
@@ -53,7 +53,7 @@ const initialState: ScheduleState = {
   totalPages: 1,
   schedules: [],
   fetchSchedulesLoading: false,
-  currentScheduleTerm: "spring2025",
+  currentScheduleTerm: "fall2025",
   preferences: {
     minUnits: "",
     maxUnits: "",

--- a/server/src/db/models/schedule/transformSection.ts
+++ b/server/src/db/models/schedule/transformSection.ts
@@ -64,6 +64,7 @@ export function transformSectionToSelectedSection(
     classPair,
     rating,
     color,
+    term: section.term,
   };
 }
 

--- a/shared/src/types/selectedSection/index.ts
+++ b/shared/src/types/selectedSection/index.ts
@@ -17,6 +17,7 @@ export type SelectedSection = {
   classPair: number | null;
   rating: number;
   color: string;
+  term?: CourseTerm;
   // Generated on frontend
   isVisible?: boolean;
   isLocked?: boolean;


### PR DESCRIPTION
## 📌 Summary
Added term validation and user-friendly toast notifications when attempting to add sections from different terms to the schedule. This prevents accidental addition of sections from incorrect terms and provides a convenient way to switch terms.

## 🔍 Related Issues
Closes #

## 🛠 Changes Made
- Added term validation check in `handleAddToCalendar` function to prevent adding sections from different terms
- Implemented toast notification with:
  - Clear error message showing course ID and class number
  - Description explaining the term mismatch
  - "Switch Term" action button for quick term switching
- Added early return when term mismatch is detected to prevent invalid section additions
- Integrated `useToast` hook in `SectionCard` component for toast functionality

## ✅ Checklist
- [x] My code follows the **PolyLink Contribution Guidelines**.
- [x] I have **tested my changes** to ensure they work as expected.
- [x] I have **documented my changes** (if applicable).
- [x] My PR has **a clear title and description**.

## 📸 Screenshots (if applicable)
N/A - Backend logic changes only

## ❓ Additional Notes
This change improves the user experience by:
1. Preventing accidental addition of sections from wrong terms
2. Providing clear feedback about term mismatches
3. Offering a convenient way to switch terms directly from the error message
4. Maintaining consistency with the existing term validation in `handleAddCourseToCalendar`

The implementation ensures that users can only add sections that match the current schedule term, reducing potential confusion and schedule conflicts.
