### PR TITLE
fixed tooltip content render bug

### DIFF
--- a/Client/src/components/ChatWidget/ChatWidget.tsx
+++ b/Client/src/components/ChatWidget/ChatWidget.tsx
@@ -228,7 +228,10 @@ export function ChatWidget({ initialOpen = false }: ChatWidgetProps) {
               ) : (
                 <div>
                   <div className="flex items-center justify-between p-3">
-                    <CurrentToolCall currentWidth={width} />
+                    <CurrentToolCall
+                      currentWidth={width}
+                      minimized={isMinimized}
+                    />
                     <div className="flex space-x-1">
                       <Button
                         variant="ghost"

--- a/Client/src/components/scheduleBuilder/aiChat/CurrentToolCall.tsx
+++ b/Client/src/components/scheduleBuilder/aiChat/CurrentToolCall.tsx
@@ -33,7 +33,13 @@ const findScrollAreaViewport = (
   ) as HTMLElement | null;
 };
 
-const CurrentToolCall = ({ currentWidth }: { currentWidth: number }) => {
+const CurrentToolCall = ({
+  currentWidth,
+  minimized,
+}: {
+  currentWidth: number;
+  minimized: boolean;
+}) => {
   const { currentAssistantMsg, currentToolCalls, assistantMsgBeingStreamed } =
     useAppSelector((state) => state.scheduleBuilderLog);
   const currentToolCall = currentToolCalls?.[currentToolCalls.length - 1];
@@ -53,6 +59,15 @@ const CurrentToolCall = ({ currentWidth }: { currentWidth: number }) => {
   const [open, setOpen] = useState(false);
   const [pinned, setPinned] = useState(false);
   const [forceMount, setForceMount] = useState(false);
+
+  // Close whenever the widget is minimised
+  useEffect(() => {
+    if (minimized) {
+      setOpen(false);
+      setPinned(false);
+      setForceMount(false);
+    }
+  }, [minimized]);
 
   // Reset tooltip when a brand‑new assistant message completes
   useEffect(() => {
@@ -167,7 +182,7 @@ const CurrentToolCall = ({ currentWidth }: { currentWidth: number }) => {
 
             <TooltipPortal>
               <TooltipContent
-                forceMount={forceMount as true}
+                forceMount={(forceMount && !minimized) as true}
                 side="top"
                 align="start"
                 alignOffset={-10}


### PR DESCRIPTION
## 📌 Summary

Added minimized state handling to the CurrentToolCall component to properly handle widget minimization behavior.

## 🔍 Related Issues

Closes #XXX

## 🛠 Changes Made

- Added `minimized` prop to `CurrentToolCall` component
- Implemented automatic closing of tooltip when widget is minimized
- Added cleanup of pinned and forceMount states on minimization
- Updated `forceMount` behavior to consider minimized state
- Modified `ChatWidget` to pass minimized state to `CurrentToolCall`

## ✅ Checklist

- [x] My code follows the **PolyLink Contribution Guidelines**.
- [x] I have **tested my changes** to ensure they work as expected.
- [x] I have **documented my changes** (if applicable).
- [x] My PR has **a clear title and description**.

## 📸 Screenshots (if applicable)

N/A

## ❓ Additional Notes

This change improves the user experience by ensuring that tooltips and tool calls are properly cleaned up when the chat widget is minimized. The implementation maintains the existing functionality while adding proper state management for the minimized state.