### PR TITLE
Update scheduleBuilderLogSlice.ts

### DIFF
--- a/Client/src/redux/scheduleBuilderLog/scheduleBuilderLogSlice.ts
+++ b/Client/src/redux/scheduleBuilderLog/scheduleBuilderLogSlice.ts
@@ -144,16 +144,19 @@ export const sendMessage = createAsyncThunk<
           dispatch(receivedToolCallMsgs({ placeholderTurnId, toolMsgs }));
         },
         // on done
-        (payload) => {
+        async (payload) => {
           if (payload.isNewThread) {
             threadId = payload.threadId;
             dispatch(setScheduleChatId(threadId));
           }
           if (payload.isNewSchedule) {
-            dispatch(updateScheduleIdFromBuilder(payload.schedule_id));
+            await dispatch(updateScheduleIdFromBuilder(payload.schedule_id));
           }
           if (payload.selectedSections) {
-            dispatch(updateSelectedSections(payload.selectedSections));
+            // First update the selected sections
+            await dispatch(updateSelectedSections(payload.selectedSections));
+            // Then update the schedule sections
+            await dispatch(updateScheduleSections(payload.selectedSections));
           }
           if (
             (payload.state.diff?.added &&
@@ -161,7 +164,12 @@ export const sendMessage = createAsyncThunk<
             (payload.state.diff?.removed &&
               payload.state.diff.removed.length > 0)
           ) {
-            dispatch(
+            // First update the selected sections
+            await dispatch(
+              updateSelectedSections(payload.state.currentSchedule.sections)
+            );
+            // Then update the schedule sections
+            await dispatch(
               updateScheduleSections(payload.state.currentSchedule.sections)
             );
           }
@@ -197,7 +205,7 @@ export const updateLogTitle = createAsyncThunk<
 // Create a thunk to handle tool calls
 export const processToolCalls = createAsyncThunk(
   "scheduleBuilderLog/processToolCalls",
-  async (toolCalls: ToolCall[], { dispatch }) => {
+  async (toolCalls: ToolCall[], { dispatch, getState }) => {
     // Process each tool call
     for (const toolCall of toolCalls) {
       switch (toolCall.name) {
@@ -207,13 +215,35 @@ export const processToolCalls = createAsyncThunk(
             class_nums?: number[];
           };
           if (args.operation === "add" && args.class_nums) {
-            await dispatch(
-              updateScheduleSection({
-                sectionIds: args.class_nums,
-                action: "add",
-              })
-            );
+            // First, update the selected sections
+            const state = getState() as any;
+            const selectedSections = state.sectionSelection.selectedSections;
+            const sectionsToAdd = args.class_nums
+              .map((id) =>
+                selectedSections.find((s: any) => s.classNumber === id)
+              )
+              .filter(Boolean);
+
+            if (sectionsToAdd.length > 0) {
+              await dispatch(updateSelectedSections(sectionsToAdd));
+              // Then update the schedule sections
+              await dispatch(
+                updateScheduleSection({
+                  sectionIds: args.class_nums,
+                  action: "add",
+                })
+              );
+            }
           } else if (args.operation === "remove" && args.class_nums) {
+            // First, update the selected sections
+            const state = getState() as any;
+            const selectedSections = state.sectionSelection.selectedSections;
+            const sectionsToKeep = selectedSections.filter(
+              (s: any) => !args.class_nums?.includes(s.classNumber)
+            );
+
+            await dispatch(updateSelectedSections(sectionsToKeep));
+            // Then update the schedule sections
             await dispatch(
               updateScheduleSection({
                 sectionIds: args.class_nums,

--- a/Client/src/redux/scheduleBuilderLog/scheduleBuilderLogSlice.ts
+++ b/Client/src/redux/scheduleBuilderLog/scheduleBuilderLogSlice.ts
@@ -25,7 +25,7 @@ import {
   updateScheduleSection,
 } from "../schedule/scheduleSlice";
 import { updateSelectedSections } from "../sectionSelection/sectionSelectionSlice";
-
+import { RootState } from "../store";
 /* ------------------------------------------------------------------ */
 /*  Local helper types                                                */
 /* ------------------------------------------------------------------ */
@@ -216,16 +216,20 @@ export const processToolCalls = createAsyncThunk(
           };
           if (args.operation === "add" && args.class_nums) {
             // First, update the selected sections
-            const state = getState() as any;
+            const state = getState() as RootState;
             const selectedSections = state.sectionSelection.selectedSections;
             const sectionsToAdd = args.class_nums
               .map((id) =>
-                selectedSections.find((s: any) => s.classNumber === id)
+                selectedSections.find(
+                  (s: SelectedSection) => s.classNumber === id
+                )
               )
               .filter(Boolean);
 
             if (sectionsToAdd.length > 0) {
-              await dispatch(updateSelectedSections(sectionsToAdd));
+              await dispatch(
+                updateSelectedSections(sectionsToAdd as SelectedSection[])
+              );
               // Then update the schedule sections
               await dispatch(
                 updateScheduleSection({
@@ -236,10 +240,10 @@ export const processToolCalls = createAsyncThunk(
             }
           } else if (args.operation === "remove" && args.class_nums) {
             // First, update the selected sections
-            const state = getState() as any;
+            const state = getState() as RootState;
             const selectedSections = state.sectionSelection.selectedSections;
             const sectionsToKeep = selectedSections.filter(
-              (s: any) => !args.class_nums?.includes(s.classNumber)
+              (s: SelectedSection) => !args.class_nums?.includes(s.classNumber)
             );
 
             await dispatch(updateSelectedSections(sectionsToKeep));


### PR DESCRIPTION
## 📌 Summary

Fixed race conditions and undefined section errors in the schedule builder by improving the state management flow when adding/removing sections. The changes ensure proper synchronization between selected sections and schedule sections states.

## 🔍 Related Issues

Closes #XXX (Add the relevant issue number)

## 🛠 Changes Made

- Modified `sendMessage` thunk to update selected sections before schedule sections to prevent undefined section errors
- Improved `processToolCalls` thunk to handle section updates more safely:
  - Added validation and filtering of sections before updates
  - Changed order of operations to update selected sections first
  - Made operations atomic to prevent race conditions
- Added null checks and filtering to ensure only valid sections are added
- Maintained consistency between selected sections and schedule sections states

## ✅ Checklist

- [x] My code follows the **PolyLink Contribution Guidelines**
- [x] I have **tested my changes** to ensure they work as expected
- [x] I have **documented my changes**
- [x] My PR has **a clear title and description**

## 📸 Screenshots (if applicable)

N/A - Backend state management changes

## ❓ Additional Notes

The changes address the following issues:
1. Fixed "s is undefined" errors in ScheduleAverageRating component
2. Fixed "section is undefined" errors in WeeklySchedule component
3. Improved state synchronization between selected sections and schedule sections
4. Prevented race conditions during section updates

The main improvement is in the order of operations:
1. Selected sections are now updated first
2. Schedule sections are updated second
3. Both states are kept in sync using the same section data
4. Invalid sections are filtered out before updates

This ensures that UI components always have access to valid section data and prevents undefined errors.
