### PR TITLE
Auto resolve conflicts

### DIFF
--- a/Client/src/components/scheduleBuilder/buildSchedule/timeConflicts/TimeConflictsPopup.tsx
+++ b/Client/src/components/scheduleBuilder/buildSchedule/timeConflicts/TimeConflictsPopup.tsx
@@ -1,12 +1,23 @@
 import { Card } from "@/components/ui/card";
-// import { Button } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import { Info, X } from "lucide-react";
-import { useAppSelector, useAppDispatch, layoutActions } from "@/redux";
+import {
+  useAppSelector,
+  useAppDispatch,
+  layoutActions,
+  scheduleActions,
+  classSearchActions,
+} from "@/redux";
 import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
+import { generateAllScheduleCombinations } from "../../helpers";
+import { CourseTerm, Section, SelectedSection } from "@polylink/shared/types";
+import { transformSectionToSelectedSection } from "@/helpers/transformSection";
 
 const TimeConflictsPopup = () => {
-  const { currentSchedule } = useAppSelector((s) => s.schedule);
+  const { currentSchedule, preferences, currentScheduleTerm } = useAppSelector(
+    (s) => s.schedule
+  );
   const [isOpen, setIsOpen] = useState(false);
   const dispatch = useAppDispatch();
   /* re-open on a *new* schedule with conflicts ---------------- */
@@ -20,10 +31,60 @@ const TimeConflictsPopup = () => {
 
     dispatch(layoutActions.fireExpandConflicts()); // <── trigger auto-open
   };
-  // const autoResolve = () => {
-  //   /* … */
-  //   console.log("autoResolve");
-  // };
+
+  const autoResolve = async () => {
+    const updatedPreferences = {
+      ...preferences,
+      withTimeConflicts: false,
+    };
+
+    const sectionsInSchedule = currentSchedule?.sections as SelectedSection[];
+
+    // 1) Build a map from courseId → color in one pass:
+    const courseColorMap = new Map<string, string>(
+      sectionsInSchedule.map((s) => [s.courseId, s.color])
+    );
+
+    const conflictingCourses =
+      currentSchedule?.conflictGroups
+        ?.flatMap((group) => group.map((s) => s.courseId))
+        .filter((courseId, index, self) => self.indexOf(courseId) === index) ||
+      [];
+
+    // 2) Figure out which ones were in conflict, fetch alternates, then
+    //    for each alternate section grab its course’s color out of the map:
+    const alternateSections = await dispatch(
+      classSearchActions.fetchSectionsByCourseIds({
+        courseIds: conflictingCourses as string[],
+        term: currentScheduleTerm as CourseTerm,
+      })
+    ).unwrap();
+
+    const alternateSelectedSections = alternateSections.map(
+      (section: Section) => {
+        const color =
+          courseColorMap.get(section.courseId) ?? /* fallback */ "#DDD";
+        return transformSectionToSelectedSection(section, color);
+      }
+    );
+
+    const sectionsWithoutConflicts = sectionsInSchedule.filter(
+      (s) => !conflictingCourses.includes(s.courseId)
+    );
+
+    const allCombinations = generateAllScheduleCombinations(
+      [...sectionsWithoutConflicts, ...alternateSelectedSections],
+      updatedPreferences
+    );
+
+    dispatch(scheduleActions.setSchedules(allCombinations));
+    dispatch(scheduleActions.setPage(1));
+    dispatch(scheduleActions.setTotalPages(allCombinations.length));
+
+    if (allCombinations.length > 0) {
+      dispatch(scheduleActions.setCurrentSchedule(allCombinations[0]));
+    }
+  };
 
   return (
     <AnimatePresence mode="wait">
@@ -69,12 +130,13 @@ const TimeConflictsPopup = () => {
               >
                 Edit Manually
               </button>
-              {/* <Button
+              <Button
+                type="button"
                 onClick={autoResolve}
                 className="dark:bg-blue-100 dark:hover:bg-blue-200 text-primary font-semibold px-5 py-2 rounded-md shadow-sm hover:bg-muted-foreground/80 transition-colors"
               >
                 Auto-Resolve
-              </Button> */}
+              </Button>
             </div>
           </Card>
         </motion.div>

--- a/Client/src/components/scheduleBuilder/buildSchedule/timeConflicts/TimeConflictsPopup.tsx
+++ b/Client/src/components/scheduleBuilder/buildSchedule/timeConflicts/TimeConflictsPopup.tsx
@@ -13,6 +13,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { generateAllScheduleCombinations } from "../../helpers";
 import { CourseTerm, Section, SelectedSection } from "@polylink/shared/types";
 import { transformSectionToSelectedSection } from "@/helpers/transformSection";
+import { environment } from "@/helpers/getEnvironmentVars";
 
 const TimeConflictsPopup = () => {
   const { currentSchedule, preferences, currentScheduleTerm } = useAppSelector(
@@ -53,17 +54,25 @@ const TimeConflictsPopup = () => {
 
     // 2) Figure out which ones were in conflict, fetch alternates, then
     //    for each alternate section grab its course’s color out of the map:
-    const alternateSections = await dispatch(
-      classSearchActions.fetchSectionsByCourseIds({
-        courseIds: conflictingCourses as string[],
-        term: currentScheduleTerm as CourseTerm,
-      })
-    ).unwrap();
+    let alternateSections: Section[] = [];
+
+    try {
+      alternateSections = await dispatch(
+        classSearchActions.fetchSectionsByCourseIds({
+          courseIds: conflictingCourses as string[],
+          term: currentScheduleTerm as CourseTerm,
+        })
+      ).unwrap();
+    } catch (error) {
+      if (environment === "dev") {
+        console.error("Failed to fetch alternate sections:", error);
+      }
+    }
 
     const alternateSelectedSections = alternateSections.map(
       (section: Section) => {
         const color =
-          courseColorMap.get(section.courseId) ?? /* fallback */ "#DDD";
+          courseColorMap.get(section.courseId) ?? /* fallback */ "#FFFFFF";
         return transformSectionToSelectedSection(section, color);
       }
     );

--- a/Client/src/components/scheduleBuilder/helpers/filterScheduleList.ts
+++ b/Client/src/components/scheduleBuilder/helpers/filterScheduleList.ts
@@ -1,7 +1,6 @@
 import { SelectedSection } from "@polylink/shared/types";
 import { SchedulePreferencesForm } from "../buildSchedule/ScheduleBuilderForm";
 import { Schedule } from ".";
-import { environment } from "@/helpers/getEnvironmentVars";
 
 function filterSchedules(
   allSchedules: SelectedSection[][],
@@ -33,14 +32,7 @@ function filterSchedules(
         unitCount += Number(unitNumber);
       }
     }
-    if (environment === "dev") {
-      console.log("--------------------------------");
-      console.log("PREFERENCES: ", preferences);
-      console.log("UNIT COUNT: ", unitCount);
-      console.log("RATING COUNT: ", ratingCount);
-      console.log("PROFESSOR WITH RATING COUNT: ", professorWithRatingCount);
-      console.log("--------------------------------");
-    }
+
     // Check the preferences to see if the schedule fits
     if (preferences.minUnits && unitCount < Number(preferences.minUnits)) {
       continue;

--- a/Client/src/helpers/transformSection.ts
+++ b/Client/src/helpers/transformSection.ts
@@ -263,3 +263,57 @@ export function transformSectionsToScheduleBuilderSections(
     })),
   }));
 }
+
+/**
+ * Transforms a Section or SectionDetail to a SelectedSection
+ * @param section The Section or SectionDetail to transform
+ * @param color The color to assign to the section (default: "#000000")
+ * @returns A SelectedSection object
+ */
+export function transformSectionToSelectedSection(
+  section: Section | SectionDetail,
+  color: string = "#000000"
+): SelectedSection {
+  // Extract the first instructor's rating or default to 0
+  const rating = section.instructorsWithRatings?.[0]?.overallRating || 0;
+
+  // Transform instructors to professors format
+  const professors =
+    section.instructorsWithRatings && section.instructorsWithRatings.length > 0
+      ? section.instructorsWithRatings.map((instructor) => ({
+          name: instructor.name,
+          id: instructor.id,
+        }))
+      : section.instructors.map((instructor) => ({
+          name: instructor.name,
+          id: instructor.name,
+        }));
+
+  // Determine classPair based on the type of section
+  let classPair: number | null = null;
+  if ("pairedSections" in section && section.pairedSections.length > 0) {
+    classPair = section.pairedSections[0];
+  } else if ("classPair" in section) {
+    classPair = section.classPair;
+  }
+
+  // Create the SelectedSection object
+  return {
+    courseId: section.courseId,
+    courseName: section.courseName,
+    classNumber: section.classNumber,
+    component: section.component,
+    units: section.units,
+    professors,
+    enrollmentStatus: section.enrollmentStatus,
+    meetings: section.meetings.map((meeting) => ({
+      days: meeting.days,
+      start_time: meeting.start_time,
+      end_time: meeting.end_time,
+    })),
+    classPair,
+    rating,
+    color,
+    term: section.term,
+  };
+}

--- a/Client/src/redux/classSearch/classSearchSlice.ts
+++ b/Client/src/redux/classSearch/classSearchSlice.ts
@@ -66,6 +66,22 @@ export const fetchSectionsAsync = createAsyncThunk(
   }
 );
 
+export const fetchSectionsByCourseIds = createAsyncThunk(
+  "sections/fetchSectionsByCourseIds",
+  async ({ courseIds, term }: { courseIds: string[]; term: CourseTerm }) => {
+    const filters = {
+      courseIds: courseIds,
+      term: term,
+    };
+    const response = await fetchSections(filters, 1);
+
+    if (response?.data.length > 0) {
+      return response.data;
+    }
+    return [];
+  }
+);
+
 export const queryAIAsync = createAsyncThunk(
   "sections/queryAI",
   async (query: string, { getState }) => {


### PR DESCRIPTION
## 📌 Summary

This PR implements an auto-resolve feature for time conflicts in the schedule builder, allowing users to automatically resolve scheduling conflicts by fetching and suggesting alternative sections for conflicting courses.

## �� Related Issues

Closes #XXX (Please add the relevant issue number)

## 🛠 Changes Made

- Implemented `autoResolve` functionality in `TimeConflictsPopup` component that:
  - Fetches alternative sections for conflicting courses
  - Preserves course colors when generating new sections
  - Generates new schedule combinations without conflicts
  - Updates the schedule state with the new combinations

- Added new Redux action `fetchSectionsByCourseIds` to fetch sections for multiple courses at once
- Added `transformSectionToSelectedSection` helper function to convert Section objects to SelectedSection format
- Removed development logging in `filterScheduleList.ts`
- Re-enabled the Auto-Resolve button in the TimeConflictsPopup UI

## ✅ Checklist

- [x] My code follows the **PolyLink Contribution Guidelines**
- [x] I have **tested my changes** to ensure they work as expected
- [x] I have **documented my changes** with JSDoc comments
- [x] My PR has **a clear title and description**

## 📸 Screenshots (if applicable)

(Please add screenshots showing the auto-resolve feature in action)

## ❓ Additional Notes

The auto-resolve feature works by:
1. Identifying courses with time conflicts
2. Fetching alternative sections for those courses
3. Preserving the original color scheme for each course
4. Generating new schedule combinations that avoid conflicts
5. Updating the UI with the new conflict-free schedules

The implementation maintains the existing color coding system and user preferences while resolving conflicts automatically.