### PR TITLE
Update CreateFlowchart.tsx

### DIFF
--- a/Client/src/components/flowchart/createFlowchart/CreateFlowchart.tsx
+++ b/Client/src/components/flowchart/createFlowchart/CreateFlowchart.tsx
@@ -23,6 +23,20 @@ import { environment } from "@/helpers/getEnvironmentVars";
 import { FlowchartData } from "@polylink/shared/types";
 import { useEffect } from "react";
 
+const userYearToStartYear = (userYear: string): string => {
+  switch (userYear) {
+    case "senior":
+      return "2021";
+    case "junior":
+      return "2022";
+    case "sophomore":
+      return "2023";
+    case "freshman":
+      return "2024";
+    default:
+      return "2024";
+  }
+};
 const CreateFlowchart = ({ onSwitchTab }: { onSwitchTab?: () => void }) => {
   const navigate = useNavigate();
 
@@ -66,14 +80,14 @@ const CreateFlowchart = ({ onSwitchTab }: { onSwitchTab?: () => void }) => {
       selections.catalog &&
       selections.major &&
       selections.concentration &&
-      (selections.startingYear || userData.year)
+      (selections.startingYear || userYearToStartYear(userData.year))
     ) {
       const flowchartData = await fetchFlowchartDataHelper(
         dispatch,
         selections.catalog,
         selections.major,
         selections.concentration.code,
-        selections.startingYear ?? userData.year,
+        selections.startingYear ?? userYearToStartYear(userData.year),
         true
       );
       await saveFlowchartToDB(flowchartData);
@@ -99,7 +113,8 @@ const CreateFlowchart = ({ onSwitchTab }: { onSwitchTab?: () => void }) => {
       // Create a new object with the updated startYear instead of modifying the original
       const updatedFlowchartData = {
         ...flowchartData,
-        startYear: selections.startingYear ?? userData.year,
+        startYear:
+          selections.startingYear ?? userYearToStartYear(userData.year),
       };
 
       flowchart = await dispatch(
@@ -121,7 +136,8 @@ const CreateFlowchart = ({ onSwitchTab }: { onSwitchTab?: () => void }) => {
                 major: selections.major ?? "",
                 catalog: selections.catalog ?? "",
                 startingYear:
-                  userData.flowchartInformation.startingYear ?? 2022,
+                  userData.flowchartInformation.startingYear ??
+                  userYearToStartYear(userData.year),
               },
             })
           );


### PR DESCRIPTION
## 📌 Summary

Added a utility function to convert user year levels (senior, junior, etc.) to actual starting years and updated the flowchart creation logic to use this conversion consistently.

## 🔍 Related Issues

Closes #XXX

## 🛠 Changes Made

- Added `userYearToStartYear` utility function to map user year levels to actual starting years:
  - Senior → 2021
  - Junior → 2022
  - Sophomore → 2023
  - Freshman → 2024
- Updated flowchart creation logic to use the new conversion function in multiple places:
  - Initial flowchart data fetching
  - Flowchart data updates
  - User data initialization

## ✅ Checklist

- [x] My code follows the **PolyLink Contribution Guidelines**.
- [x] I have **tested my changes** to ensure they work as expected.
- [x] I have **documented my changes** (if applicable).
- [x] My PR has **a clear title and description**.

## ❓ Additional Notes

This change ensures consistent handling of starting years across the application by centralizing the year conversion logic in a single utility function. The default year is set to 2024 (freshman) when no valid year is provided.